### PR TITLE
Add extras_require for odbc packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,12 @@ setup(
         ],
     platforms='any',  # or distutils.util.get_platform()
     install_requires=['sqlalchemy'],
+    extras_require={
+        'pyodbc' : ['pyodbc', ],
+        'pypyodbc' : ['pypyodbc', ],
+#        'pypyodbc,pyodbc' : ['pypyodbc', 'pyodbc', ],
+        'all' : ['pypyodbc', 'pyodbc', ],
+    },
 
     entry_points = {                                                
         'sqlalchemy.dialects': [                                    

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ setup(
     extras_require={
         'pyodbc' : ['pyodbc', ],
         'pypyodbc' : ['pypyodbc', ],
-#        'pypyodbc,pyodbc' : ['pypyodbc', 'pyodbc', ],
         'all' : ['pypyodbc', 'pyodbc', ],
     },
 


### PR DESCRIPTION
### Overview
Added `extras_require` section for installing ODBC package(s). Reference #26 

e.g.

    pip install "sqlalchemy-ingres[pyodbc]"
    pip install "sqlalchemy-ingres[pypyodbc]"
    pip install "sqlalchemy-ingres[pypyodbc,pyodbc]"
    pip install "sqlalchemy-ingres[all]"

### Testing/Verification

#### Built wheel file

    C:\work>python -m pip install --upgrade setuptools wheel
    C:\work>python setup.py sdist bdist_wheel
    C:\work>dir /b .\dist
    sqlalchemy-ingres-0.0.4.dev1.tar.gz
    sqlalchemy_ingres-0.0.4.dev1-py3-none-any.whl

#### Tested variances of install
    C:\work\dist>python -m pip install sqlalchemy_ingres-0.0.4.dev1-py3-none-any.whl[pyodbc]

    C:\work\dist>python -m pip install sqlalchemy_ingres-0.0.4.dev1-py3-none-any.whl[pypyodbc]

    C:\work\dist>python -m pip install sqlalchemy_ingres-0.0.4.dev1-py3-none-any.whl[pypyodbc,pyodbc]

    C:\work\dist>python -m pip install sqlalchemy_ingres-0.0.4.dev1-py3-none-any.whl[pyodbc,pypyodbc]

    C:\work\dist>python -m pip install sqlalchemy_ingres-0.0.4.dev1-py3-none-any.whl[all]

Each command properly installed the identified package(s) and other dependencies.