### PR TITLE
Fix get_primary_keys return type

### DIFF
--- a/lib/sqlalchemy_ingres/_version.py
+++ b/lib/sqlalchemy_ingres/_version.py
@@ -1,2 +1,2 @@
-version_tuple = __version_info__ = (0, 0, 5, 'dev1')
+version_tuple = __version_info__ = (0, 0, 6)
 version = version_string = __version__ = '.'.join(map(str, __version_info__))

--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -376,8 +376,10 @@ class IngresDialect(default.DefaultDialect):
         
         try:
             rs = connection.exec_driver_sql(sqltext, params)
-            
-            return [row[0].rstrip() for row in rs.fetchall()]
+
+            cols = [row[0].rstrip() for row in rs.fetchall()]
+            return {"constrained_columns": [] if cols is None else cols, "name": None}
+
         finally:
             if rs:
                 rs.close()


### PR DESCRIPTION
### Description
Fix TypeError when querying primary key metadata using reflection.

Related issue #22 

Stack dump excerpt and error:

      File "C:\work\.venv\lib\site-packages\sqlalchemy\engine\reflection.py",
            line 1703, in _reflect_pk
        for pk in pk_cons["constrained_columns"]
    TypeError: list indices must be integers or slices, not str

### Solution

The fix modifies `base.py` so that the return type from `get_primary_keys` (wrapped by `get_pk_constraint`) is now a dictionary (versus a list) and contains the primary key (i.e. constrained column) name.

_Note: This solution works with SQLAlchemy version 2.0.27. I was unable to test with SQLAlchemy version 1.4.51 due to an unrelated error that will be addressed in a separate issue._

### Testing
Packages and test cases used to verify the fix.  

Without the fix, each test case failed with `TypeError: list indices must be integers or slices, not str`.  

With the fix in place, each test case ran successfully.

#### Versions of selected Python packages used in testing

    langchain           0.1.7
    langchain-community 0.0.20
    langchain-core      0.1.23
    langsmith           0.0.87
    pyodbc              5.1.0
    pypyodbc            1.3.6
    setuptools          63.2.0
    SQLAlchemy          2.0.27
    sqlalchemy-ingres   0.0.5.dev1

#### Test case 1
[test1.py.txt](https://github.com/ActianCorp/sqlalchemy-ingres/files/14303022/test1.py.txt)  (based on the example in [comment](https://github.com/ActianCorp/sqlalchemy-ingres/issues/22#issue-1757395057))


#### Test case 2
[test2.py.txt](https://github.com/ActianCorp/sqlalchemy-ingres/files/14303023/test2.py.txt)  (based on the example in [comment](https://github.com/ActianCorp/sqlalchemy-ingres/issues/22#issuecomment-1592138066))

### Notable SQLAlchemy related changes

[changelog_06.rst](https://github.com/sqlalchemy/sqlalchemy/blob/main/doc/build/changelog/changelog_06.rst) - May 16, 2022  

    Added get_pk_constraint() to reflection.Inspector, similar
    to get_primary_keys() except returns a dict that includes the
    name of the constraint, for supported backends (PG so far).

[changelog_08.rst](https://github.com/sqlalchemy/sqlalchemy/blob/main/doc/build/changelog/changelog_08.rst) - Oct 2, 2022  

    Inspector.get_primary_keys() is
    deprecated; use Inspector.get_pk_constraint().

[changelog_14.rst](https://github.com/sqlalchemy/sqlalchemy/blob/main/doc/build/changelog/changelog_14.rst) - Jan 2, 2024  

    Remove deprecated method ``get_primary_keys`` in the :class:`.Dialect`
    and :class:`_reflection.Inspector` classes. Please refer to the
    :meth:`.Dialect.get_pk_constraint`
    and :meth:`_reflection.Inspector.get_primary_keys` methods.

### Question to consider
Would it be valuable for`get_pk_constraint/get_primary_keys` to also return the constraint name (in addition to the column name)? I checked the `iikeys` table of my Actian X 11.2 data database and found these examples of constraint names for defined primary keys:  `$user__U0000025B0000, $addre_U0000025E0000, $famil_U000002E90000`  I don't know whether these constraint names would be at all useful when retrieving primary key metadata.