### PR TITLE
Fix tuple append

### DIFF
--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -376,9 +376,8 @@ class IngresDialect(default.DefaultDialect):
         
         try:
             rs = connection.exec_driver_sql(sqltext, params)
-        
+            
             return [row[0].rstrip() for row in rs.fetchall()]
-
         finally:
             if rs:
                 rs.close()

--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -376,8 +376,9 @@ class IngresDialect(default.DefaultDialect):
         
         try:
             rs = connection.exec_driver_sql(sqltext, params)
-            
+        
             return [row[0].rstrip() for row in rs.fetchall()]
+
         finally:
             if rs:
                 rs.close()
@@ -558,7 +559,7 @@ class IngresDialect(default.DefaultDialect):
         if schema:
             sqltext += """
                 AND table_owner = ?"""
-            params(*params, self.denormalize_name(schema))
+            params = (*params, self.denormalize_name(schema))
         else:
             sqltext += """
                 AND table_owner != '$ingres'"""
@@ -596,7 +597,7 @@ class IngresDialect(default.DefaultDialect):
         if schema:
             sqltext += """
                 AND i.index_owner = ?"""
-            params(*params, self.denormalize_name(schema))
+            params = (*params, self.denormalize_name(schema))
             
         sqltext += """
             ORDER BY


### PR DESCRIPTION
### Description

Fixed a couple of cases for appending a parameter to the `params` tuple variable.

### Test cases

Package versions using in testing

    greenlet          3.0.3
    pip               24.0
    pyodbc            5.1.0
    pypyodbc          1.3.6
    setuptools        63.2.0
    SQLAlchemy        2.0.27
    sqlalchemy-ingres 0.0.5.dev1
    typing_extensions 4.9.0
<br>

    # testIndexes.py

    import os
    import sys
    import sqlalchemy
    import sqlalchemy_ingres
    print('Python %s on %s' % (sys.version, sys.platform))
    print('SQLAlchemy %r' % sqlalchemy.__version__)
    driver_name = os.environ.get('SQLALCHEMY_INGRES_ODBC_DRIVER_NAME') or 'Actian'
    print('SQLALCHEMY_INGRES_ODBC_DRIVER_NAME %r' % driver_name)
    con_str = os.environ['DATABASE_URI']
    engine = sqlalchemy.create_engine(con_str)
    schema = "actian"
    table_name = "demotable"
    inspector = sqlalchemy.inspect(engine)
    inspector.get_indexes(table_name=table_name, schema=schema)
    metadata = sqlalchemy.MetaData()
    view_support = False
    metadata.reflect( views=view_support, bind=engine, schema=schema, )
<br>

    # testViewDefn.py

    import os
    import sys
    import sqlalchemy
    import sqlalchemy_ingres
    print('Python %s on %s' % (sys.version, sys.platform))
    print('SQLAlchemy %r' % sqlalchemy.__version__)
    driver_name = os.environ.get('SQLALCHEMY_INGRES_ODBC_DRIVER_NAME') or 'Actian'
    print('SQLALCHEMY_INGRES_ODBC_DRIVER_NAME %r' % driver_name)
    con_str = os.environ['DATABASE_URI']
    engine = sqlalchemy.create_engine(con_str)
    schema = "actian"
    view_name = "demoview"
    inspector = sqlalchemy.inspect(engine)
    inspector.get_view_definition(view_name=view_name, schema=schema)
    metadata = sqlalchemy.MetaData()
    view_support = True
    metadata.reflect( views=view_support, bind=engine, schema=schema, )

### Output showing failures without the fix

    (.venv) λ python testIndexes.py
    Python 3.10.7 (tags/v3.10.7:6cc6b13, Sep  5 2022, 14:08:36) [MSC v.1933 64 bit (AMD64)] on win32
    SQLAlchemy '2.0.27'
    SQLALCHEMY_INGRES_ODBC_DRIVER_NAME 'Actian II'
    Traceback (most recent call last):
      File "C:\github29\testIndexes.py", line 22, in <module>
        inspector.get_indexes(table_name=table_name, schema=schema)
      File "C:\github29\.venv\lib\site-packages\sqlalchemy\engine\reflection.py", line 1135, in get_indexes
        return self.dialect.get_indexes(
      File "<string>", line 2, in get_indexes
      File "C:\github29\.venv\lib\site-packages\sqlalchemy\engine\reflection.py", line 97, in cache
        ret = fn(self, con, *args, **kw)
      File "C:\github29\sqlalchemy-ingres\lib\sqlalchemy_ingres\base.py", line 599, in get_indexes
        params(*params, self.denormalize_name(schema))
    TypeError: 'tuple' object is not callable


    (.venv) λ python testViewDefn.py
    Python 3.10.7 (tags/v3.10.7:6cc6b13, Sep  5 2022, 14:08:36) [MSC v.1933 64 bit (AMD64)] on win32
    SQLAlchemy '2.0.27'
    SQLALCHEMY_INGRES_ODBC_DRIVER_NAME 'Actian II'
    Traceback (most recent call last):
      File "C:\github29\testViewDefn.py", line 22, in <module>
        inspector.get_view_definition(view_name=view_name, schema=schema)
      File "C:\github29\.venv\lib\site-packages\sqlalchemy\engine\reflection.py", line 828, in get_view_definition
        return self.dialect.get_view_definition(
      File "<string>", line 2, in get_view_definition
      File "C:\github29\.venv\lib\site-packages\sqlalchemy\engine\reflection.py", line 97, in cache
        ret = fn(self, con, *args, **kw)
      File "C:\github29\sqlalchemy-ingres\lib\sqlalchemy_ingres\base.py", line 561, in get_view_definition
        params(*params, self.denormalize_name(schema))
    TypeError: 'tuple' object is not callable

### Output with the fix

    (.venv) λ python testIndexes.py
    Python 3.10.7 (tags/v3.10.7:6cc6b13, Sep  5 2022, 14:08:36) [MSC v.1933 64 bit (AMD64)] on win32
    SQLAlchemy '2.0.27'
    SQLALCHEMY_INGRES_ODBC_DRIVER_NAME 'Actian II'


    (.venv) λ python testViewDefn.py
    Python 3.10.7 (tags/v3.10.7:6cc6b13, Sep  5 2022, 14:08:36) [MSC v.1933 64 bit (AMD64)] on win32
    SQLAlchemy '2.0.27'
    SQLALCHEMY_INGRES_ODBC_DRIVER_NAME 'Actian II'