### PR TITLE
Improve SQL row limiting and metadata operations

### DIFF
--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -158,10 +158,10 @@ class IngresSQLCompiler(compiler.SQLCompiler):
         # NOTE this now silently ignores keyword argument 'literal_binds', 'enclosing_alias', 'include_table', etc.
         text = ""
         if not self.is_subquery():
-            if select._offset is not None and select._offset > 0:
+            if is_integer_greater_than_zero(select._offset):
                 text += '\nOFFSET %s' % select._offset
-            if select._limit is not None and select._limit > 0:
-                if select._offset is not None and select._offset > 0:
+            if is_integer_greater_than_zero(select._limit):
+                if is_integer_greater_than_zero(select._offset):
                	    text += '\nFETCH FIRST %s ROWS ONLY' % select._limit
                 else:
                	    text += '\nLIMIT %s' % select._limit
@@ -706,3 +706,8 @@ class IngresDialect(default.DefaultDialect):
             if rs:
                 rs.close()
     _get_default_schema_name = get_default_schema_name  # 1.4 API
+
+
+def is_integer_greater_than_zero(check_value):
+    return check_value is not None and check_value > 0
+

--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -643,7 +643,7 @@ class IngresDialect(default.DefaultDialect):
         if name is None:
             return None
         else:
-            return name.encode('latin1')
+            return name.lower().encode('latin1')
         
     def has_table(self, connection, table_name, schema=None):
         sqltext = """

--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -157,12 +157,14 @@ class IngresSQLCompiler(compiler.SQLCompiler):
     def limit_clause(self, select, **kwargs):
         # NOTE this now silently ignores keyword argument 'literal_binds', 'enclosing_alias', 'include_table', etc.
         text = ""
-        
         if not self.is_subquery():
-            if select._offset:
+            if select._offset is not None and select._offset > 0:
                 text += '\nOFFSET %s' % select._offset
-            if select._limit:
-                text += '\nFETCH FIRST %s ROWS ONLY' % select._limit
+            if select._limit is not None and select._limit > 0:
+                if select._offset is not None and select._offset > 0:
+               	    text += '\nFETCH FIRST %s ROWS ONLY' % select._limit
+                else:
+               	    text += '\nLIMIT %s' % select._limit
         return text
     
     def get_select_precolumns(self, select, **kwargs):
@@ -641,7 +643,7 @@ class IngresDialect(default.DefaultDialect):
         if name is None:
             return None
         else:
-            return name.lower().encode('latin1')
+            return name.encode('latin1')
         
     def has_table(self, connection, table_name, schema=None):
         sqltext = """


### PR DESCRIPTION
### Overview
These code changes are an attempt to improve some operations in Apache Superset SQL Lab when using the Ingres dialect for SQLAlchemy.

Related internal ticket [II-13536](https://actian.atlassian.net/browse/II-13536)

### Details
When using the SQLAlchemy-Ingres dialect in Apache Superset SQL Lab, there are a couple of unrelated problems that occur, both when choosing a table from the **SEE TABLE SCHEMA** drop list which attempts to execute a SQL SELECT statement to retrieve rows from the target table.

#### Problems

1. The code in `IngresDialect::get_columns` calls `IngresDialect::denormalize_name`, which converts the given string to all lowercase. If the table name is mixed (or upper) case, the SQL statement to retrieve column names returns no rows, which causes Superset to build a syntactically invalid SELECT statement that specifies no columns.  It is important to note that this problem could also manifest outside of Apache Superset given the right conditions.
2. The `IngresDialect::limit_clause` is called which returns a row limiting clause using `FIRST FETCH n ROWS ONLY` after which Superset also appends `LIMIT n`, causing a syntactically incorrect SQL statement having two row limiting clauses. Superset appears to not have the ability to recognize the `FETCH FIRST ...` clause so that it could handle it properly and avoid adding the `LIMIT` clause.

#### Fixes / Workarounds

1. The simple fix is to remove the lowercase conversion, leaving the table name as is.
2. The fix to method `IngresDialect::limit_clause` gives precedence to the `LIMIT n` clause and only uses `FETCH FIRST n ROWS ONLY` if there is also an `OFFSET m` clause. When the row limiting clause is `LIMIT n`, Superset will not append another "LIMIT" clause and the SQL statement remains syntactically valid.

### SQLAlchemy Test Suite Results

SQLAlchemy 2.0.27<br>18342 tests | Passed | Failed | Errors | Skipped | Warnings
--|--|--|--|--|--
Before Fixes | 12399 | 1904 | 2220 | 2020 | 8
After Fixes | 12424 | 1930 | 2156 | 2020 | 9
Diffs | +25 | +26 | -64 | - | +1

SQLAlchemy 1.4.51<br>13909 tests | Passed | Failed | Errors | Skipped
--|--|--|--|--
Before Fixes | 9277 | 1883 | 2080 | 730
After Fixes | 9291 | 1891 | 2077 | 730
Diffs | +14 | +8 | -3 | -

### Concerns

1. The Ingres dialect needs a more robust way of handling case of identifiers. Ingres Terminal Monitor code would be a good reference for this.
2. The Superset config parameter `SQL_MAX_ROW` affects behavior in Superset SQL Lab. Without the proposed fix to the SQLAlchemy Ingres dialect `limit_clause` method, adhoc queries having a `FETCH FIRST ...` row limiting clause always fail with a syntax error since Superset adds the redundant `LIMIT n` clause. However, with the fix to method `limit_clause`, adhoc queries using a `FETCH FIRST ...` row limiting clause will work if `SQL_MAX_ROW` is set to `0` (zero). If `SQL_MAX_ROW` is set to a value > 0, Superset appends a `LIMIT` clause causing a syntax error. Adhoc queries using `LIMIT` for row limiting work regardless of the value of `SQL_MAX_ROW`.


