### PR TITLE
Fix identifier case handling

### DIFF
--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -643,7 +643,7 @@ class IngresDialect(default.DefaultDialect):
         if name is None:
             return None
         else:
-            return name.lower().encode('latin1')
+            return name
         
     def has_table(self, connection, table_name, schema=None):
         sqltext = """

--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -636,7 +636,7 @@ class IngresDialect(default.DefaultDialect):
         if name is None:
             return None
         else:
-            return name.decode('latin1')
+            return name
         
     
     def denormalize_name(self, name):


### PR DESCRIPTION
### Description
Removed forced conversion of identifiers to lowercase so that uppercase and mixed-case scenarios now work properly.

Also removed encoding/decoding of string to bytes.  Proper handling (if needed) will be dealt with via #36.

### Testing - Python Script
Ran the attached case_test.py which uses SQLAlchemy inspection to get column information for existing tables. Target DBMS tested: Vector 6.3 database on Ubuntu and Ingres 11.2 database on Windows

[case_test.py.txt](https://github.com/ActianCorp/sqlalchemy-ingres/files/14706188/case_test.py.txt)

#### Example output
```
Python 3.10.7 (tags/v3.10.7:6cc6b13, Sep  5 2022, 14:08:36) [MSC v.1933 64 bit (AMD64)] on win32

2.0.28
ingres://testuser:TESTPWD@TESTMACHINE:21064/casedb
(['Driver={Actian II};Database=casedb;HostName=TESTMACHINE;ListenAddress=21064;UID=testuser;PWD=TESTPWD'], {})
('II 11.2.0 (a64.win/100)',)
('testuser                        ', 'otheruser                       ', '$ingres                         ')
('DB_DELIMITED_CASE               ', 'MIXED                           ')
('DB_NAME_CASE                    ', 'LOWER                           ')
('DB_REAL_USER_CASE               ', 'LOWER                           ')
('MIXEDCASE_NAMES                 ', 'N                               ')

============================================================================
================  Table names as stored with actual case  ==================
============================================================================
('TABLE UPPER DELIMITED ',)
('Table Mixed Delimited ',)
('table lower delimited ',)
('table_lower ',)
('table_mixed ',)
('table_upper ',)

=====================================================================================
=====  Table Names Inspections using SQLAlchemy-Ingres method: get_table_names  =====
=====================================================================================
['TABLE UPPER DELIMITED', 'table_lower', 'table lower delimited', 'table_upper', 'Table Mixed Delimited', 'table_mixed']

=======================================================
===============  Columns of each table  ===============
=======================================================
Columns for table ( TABLE UPPER DELIMITED ): [{'name': 'COL1 DELIM', 'nullable': True, 'default': None, 'type': Integer()}]
Columns for table ( table_lower ): [{'name': 'col1', 'nullable': True, 'default': None, 'type': Integer()}]
Columns for table ( table lower delimited ): [{'name': 'col1 delim', 'nullable': True, 'default': None, 'type': Integer()}]
Columns for table ( table_upper ): [{'name': 'col1', 'nullable': True, 'default': None, 'type': Integer()}]
Columns for table ( Table Mixed Delimited ): [{'name': 'Col1 Delim', 'nullable': True, 'default': None, 'type': Integer()}]
Columns for table ( table_mixed ): [{'name': 'col1', 'nullable': True, 'default': None, 'type': Integer()}]
```

### Testing - Apache Superset

    Python 3.10.12

    apache-superset           3.1.1
    pyodbc                    5.1.0
    pypyodbc                  1.3.6
    SQLAlchemy                1.4.51.dev0
    sqlalchemy-ingres         0.0.7.dev1

Tested Superset's auto-retrieval of column metadata and row data in **Superset SQL Lab**, plus adhoc SQL statements in SQL Lab. Used backends of Ingres 11.2 on Windows and Vector 6.3 on Ubuntu. All sanity tests ran successfully, correctly retrieving the data.