### PR TITLE
Fixes for errors running dialect compliance suite

### DIFF
--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -254,6 +254,11 @@ class IngresDDLCompiler(compiler.DDLCompiler):
             or not column.nullable
             ):
                 colspec += " NOT NULL"
+        else:
+            for x in column.table.constraints:
+                if x.contains_column(column):
+                    colspec += " NOT NULL"
+                    break
 
         return colspec
 
@@ -289,6 +294,7 @@ class IngresDDLCompiler(compiler.DDLCompiler):
                 text += ' ON '
                 text += ", ".join(["%s" % col for col in modify.kwargs['ingres_structure_keys']])
         return text
+
     
 class IngresExecutionContext(default.DefaultExecutionContext):
     _select_lastrowid = False
@@ -389,6 +395,9 @@ class IngresDialect(default.DefaultDialect):
 
     def __init__(self, **kwargs):
         default.DefaultDialect.__init__(self, **kwargs)
+
+    def get_isolation_level_values(self, connection):
+        return list(self._isolation_lookup)
 
     @reflection.cache        
     def get_columns(self, connection, table_name, schema=None, **kw):

--- a/lib/sqlalchemy_ingres/provision.py
+++ b/lib/sqlalchemy_ingres/provision.py
@@ -1,0 +1,6 @@
+from sqlalchemy.testing.provision import temp_table_keyword_args
+
+@temp_table_keyword_args.for_db("ingres")
+def _ingres_temp_table_keyword_args(cfg, eng):
+    return {}
+


### PR DESCRIPTION
### Summary
Code changes to fix several errors that occur when running the SQLAlchemy dialect compliance suite with the Ingres dialect and an Ingres 11.2 database. The fixes allow the relevant tests to run beyond specific points of failure. Other errors are subsequently encountered and will be dealt with in different issues.

### Environment and versions
Partial list of Python packages. Client and server are the same machine.

    Microsoft Windows [Version 10.0.19045.4170]
    Database: Ingres 11.2.0 (a64.win/100) 15807
    Python 3.10.7
    mock              5.1.0
    pip               24.0
    pluggy            1.5.0
    pyodbc            5.1.0
    pypyodbc          1.3.6
    pytest            8.2.0
    setuptools        63.2.0
    SQLAlchemy        2.0.29.dev0
    sqlalchemy-ingres 0.0.7.dev1
    tox               4.15.0
 
### Fix 1 
Internal tracking [II-14170](https://actian.atlassian.net/browse/II-14170)

Various tests such as [AutocommitIsolationTest](https://github.com/sqlalchemy/sqlalchemy/blob/f00f34437d37f4776b323317432167ad5fe8413b/lib/sqlalchemy/testing/suite/test_dialect.py#L279) fail with these messages:

    TypeError: 'NoneType' object is not subscriptable

The error is alleviated by adding method `get_isolation_level_values` to class IngresDialect that returns the list of isolation level keywords supported by Ingres.

With the fix, a new error `DBAPI has no isolation level support` occurs that will be dealt with in a separate issue (TBD).

### Fix 2
Internal tracking [II-14171](https://actian.atlassian.net/browse/II-14171)

The `ComponentReflectionTest` class contains 732 tests, all of which fail with this error:

    NotImplementedError: no temp table keyword args routine for cfg:
    ingres+pyodbc:///sqatestdb

The error is alleviated by adding a decorated method in new file **provision.py**.

### Fix 3
After fixing the above error that reported `no temp table keyword args routine for cfg`, many of the tests in class `ComponentReflectionTest` subsequently failed with the following error _(example with the corresponding bad SQL)_:

    sqlalchemy.exc.ProgrammingError: (pyodbc.ProgrammingError) ('42000', "[42000]
    [Actian][Actian II ODBC Driver][INGRES]  CREATE TABLE: A column in a UNIQUE
    constraint has been defined as WITH NULL (on table 'user_tmp_main'). All columns
    in a UNIQUE constraint MUST be created as NOT NULL. (328832) (SQLExecDirectW)")

    [SQL:
    CREATE TABLE user_tmp_main (
        id INTEGER GENERATED BY DEFAULT AS IDENTITY NOT NULL,
        name VARCHAR(50),
        foo INTEGER,
        PRIMARY KEY (id),
        CONSTRAINT user_tmp_uq_main UNIQUE (name) )

The error is alleviated in the Ingres dialect during column processing by checking whether any of the table columns are part of a unique constraint of the same table and if so, adding a `NOT NULL` clause for the column.

### Future Fix
Upon applying the above fixes, many of the affected test cases now fail with the following (already known) error when using the Ingres dialect that is being tracked by internal ticket [II-14148](https://actian.atlassian.net/browse/II-14148).

    [42503] [Actian][Actian II ODBC Driver][INGRES]CREATE TABLE:
    You may not create an object owned by 'test_schema'. (328737) (SQLExecDirectW)")
    [SQL:
    CREATE TABLE test_schema.users (
        user_id INTEGER GENERATED BY DEFAULT AS IDENTITY NOT NULL,
        test1 CHAR(5) NOT NULL,
        test2 FLOAT NOT NULL,
        parent_user_id INTEGER NOT NULL,
        PRIMARY KEY (user_id),
        CONSTRAINT zz_test2_gt_zero CHECK (test2 > 0),
        CHECK (test2 <= 1000),
        CONSTRAINT user_id_fk FOREIGN KEY(parent_user_id)
            REFERENCES test_schema.users (user_id) ) ]