### PR TITLE
Ensure lastrowid value exists before trying to assign it

### DIFF
--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -349,7 +349,8 @@ class IngresExecutionContext(default.DefaultExecutionContext):
             )
             # fetchall() ensures the cursor is consumed without closing it
             row = self.cursor.fetchall()[0]
-            self._lastrowid = int(row[0])
+            if row[0] is not None:
+                self._lastrowid = int(row[0])
 
             self.cursor_fetch_strategy = _cursor._NO_CURSOR_DML
         elif (


### PR DESCRIPTION
### Description
Fix that avoids trying to assign a value in cases where no value exists after calling the Ingres [LAST_IDENTITY](https://docs.actian.com/actianx/11.2/index.html#page/SQLRef/Sequence_Expressions.htm) function during SQL post processing.

Prevents error: `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'` when running a number of tests.

### Environment

    Ingres 11.2 (15807) on Windows 10 (client & server are same)
    Python 3.10.7
    mock 5.1.0
    packaging 24.0
    pip 24.0
    pluggy 1.5.0
    pyodbc 5.1.0
    pypyodbc 1.3.6
    pytest 8.2.0
    setuptools 63.2.0
    SQLAlchemy 2.0.29.dev0
    sqlalchemy-ingres 0.0.7.dev1
    tox 4.15.0

Related ticket:  [II-14233](https://actian.atlassian.net/browse/II-14233)

### Results using various tests from the SQLAlchemy dialect compliance suite

WITHOUT FIX | Pass | Fail
--|--|--
BinaryTest | 0 | 3
DateTest | 2 | 4
DateTimeCoercedToDateTimeTest | 2 | 4
DateTimeMicrosecondsTest | 0 | 5
DateTimeTest | 2 | 4
DifficultParametersTest | 42 | 21
IntegerTest | 1 | 22
IsOrIsNotDistinctFromTest | 0 | 5
**Results without fix** | **49** | **68**

WITH FIX | Pass | Fail
--|--|--
BinaryTest | 3 | 0
DateTest | 6 | 0
DateTimeCoercedToDateTimeTest | 6 | 0
DateTimeMicrosecondsTest | 2 | 3 _(a)_
DateTimeTest | 6 | 0
DifficultParametersTest | 63 | 0
IntegerTest | 12 | 11 _(b)_
IsOrIsNotDistinctFromTest | 5 | 0
**Results with fix** | **103** | **14**

_(a) Different error now occurs: AssertionError_
_(b) Different error now occurs due to unrelated bad SQL syntax_