### PR TITLE
Add custom requirements.py

### DIFF
--- a/lib/sqlalchemy_ingres/_version.py
+++ b/lib/sqlalchemy_ingres/_version.py
@@ -1,2 +1,2 @@
-version_tuple = __version_info__ = (0, 0, 7, "dev2")
+version_tuple = __version_info__ = (0, 0, 7, "dev3")
 version = version_string = __version__ = '.'.join(map(str, __version_info__))

--- a/lib/sqlalchemy_ingres/requirements.py
+++ b/lib/sqlalchemy_ingres/requirements.py
@@ -1,0 +1,39 @@
+from sqlalchemy.testing.requirements import SuiteRequirements
+
+from sqlalchemy.testing import exclusions
+
+class Requirements(SuiteRequirements):
+    @property
+    def date_historic(self):
+        """target dialect supports representation of Python
+        datetime.datetime() objects with historic (pre 1970) values."""
+        return exclusions.open()
+
+    @property
+    def datetime_historic(self):
+        """target dialect supports representation of Python
+        datetime.datetime() objects with historic (pre 1970) values."""
+        return exclusions.open()
+
+    @property
+    def datetime_literals(self):
+        """target dialect supports rendering of a date, time, or datetime as a
+        literal string, e.g. via the TypeEngine.literal_processor() method.
+
+        """
+        return exclusions.open()
+
+    @property
+    def identity_columns(self):
+        """If a backend supports GENERATED { ALWAYS | BY DEFAULT }
+        AS IDENTITY"""
+        return exclusions.open()
+
+    @property
+    def identity_columns_standard(self):
+        """If a backend supports GENERATED { ALWAYS | BY DEFAULT }
+        AS IDENTITY with a standard syntax.
+        This is mainly to exclude MSSql.
+        """
+        return exclusions.open()
+


### PR DESCRIPTION
### Description
This PR adds a custom **requirements.py** in which the SQLAlchemy testing class **SuiteRequirements** is subclassed allowing the SQLAlchemy testing framework to better understand the capabilities of the Ingres dialect. This further allows results from running the SQLAlchemy [dialect compliance suite](https://github.com/sqlalchemy/sqlalchemy/tree/main/lib/sqlalchemy/testing/suite) to be more accurate in order to more easily make improvements to the Ingres dialect. For additional details, see [README.dialects.rst](https://github.com/sqlalchemy/sqlalchemy/blob/main/README.dialects.rst).

Internal ticket [II-14269](https://actian.atlassian.net/browse/II-14269)

### Testing Enablement
In order for the SQLAlchemy test runner to be able to discover the SQLAlchemy-Ingres requirements.py which contains (overridden) properties specific to the Ingres dialect, the following entry needs to be made in the setup.cfg (or test.cfg) of the SQLAlchemy cloned repository.

    [sqla_testing]
    requirement_cls=sqlalchemy_ingres.requirements:Requirements

### Test Environment
    Microsoft Windows [Version 10.0.19045.4170]

    Ingres II 11.2.0 (a64.win/100) 15807 + Actian Client 1.0.0-139-win-x86_64

    Python 3.10.7

    mock              5.1.0
    packaging         24.0
    pip               24.0
    pluggy            1.5.0
    pyodbc            5.1.0
    pyproject-api     1.6.1
    pypyodbc          1.3.6
    pytest            8.2.0
    setuptools        63.2.0
    SQLAlchemy        2.0.29.dev0
    sqlalchemy-ingres 0.0.7.dev2
    tox               4.15.0
    typing_extensions 4.11.0

### Affected Tests
Test Class | Test | Directives opened in<br>Ingres dialect requirements.py | Before | After
--|--|--|--|--
 DateHistoricTest | test_literal | date_historic, datetime_literals | SKIPPED | PASSED
 DateHistoricTest | test_null | date_historic | SKIPPED | PASSED
 DateHistoricTest | test_null_bound_comparison | date_historic | SKIPPED | PASSED
 DateHistoricTest | test_round_trip | date_historic | SKIPPED | PASSED
 DateHistoricTest | test_round_trip_decorated | date_historic | SKIPPED | PASSED
 DateHistoricTest | test_select_direct | date_historic | SKIPPED | PASSED
 | | | | 
DateTimeHistoricTest | test_literal | test_literal  datetime_historic | SKIPPED | PASSED
DateTimeHistoricTest | test_null | datetime_historic | SKIPPED | PASSED
DateTimeHistoricTest | test_null_bound_comparison | datetime_historic | SKIPPED | PASSED
DateTimeHistoricTest | test_round_trip | datetime_historic | SKIPPED | PASSED
DateTimeHistoricTest | test_round_trip_decorated | datetime_historic | SKIPPED | PASSED
DateTimeHistoricTest | test_select_direct | datetime_historic | SKIPPED | PASSED
 | | | | 
IdentityColumnTest | test_insert_always_error | identity_columns, identity_columns_standard | SKIPPED | PASSED
IdentityColumnTest | test_select_all | identity_columns | SKIPPED | PASSED
IdentityColumnTest | test_select_columns | identity_columns | SKIPPED | PASSED