### PR TITLE
Added method get_unique_constraints II-14372

### DIFF
--- a/lib/sqlalchemy_ingres/_version.py
+++ b/lib/sqlalchemy_ingres/_version.py
@@ -1,2 +1,2 @@
-version_tuple = __version_info__ = (0, 0, 7, "dev4")
+version_tuple = __version_info__ = (0, 0, 7, "dev5")
 version = version_string = __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
### Description
Added reflection method `get_unique_constraints` to retrieve names of existing unique constraints.

### Error fixed when running the SQLAlchemy dialect compliance suite

    File "C:\.....\sqlalchemy\lib\sqlalchemy\engine\interfaces.py", line 1613,
     in get_unique_constraints
    raise NotImplementedError()
    NotImplementedError

### Testing - How to reproduce (before fix)
1. Configure SQLAlchemy dialect compliance suite testing according to the instructions in [README.testsuite.md](https://github.com/ActianCorp/sqlalchemy-ingres/blob/master/README.testsuite.md)
2. Run unique_constraints tests:
`pytest --db ingres_odbc --maxfail=100 test_suite_reflection.py -k "test_get_multi_unique_constraints"`

### Impact of fix
Results | Passed | Failed
--|--|--
Before Fix | 0 | 42
After Fix | 26 |16

_The remaining 16 failed tests are caused by different issues and will be handled separately._

### Environment
    Microsoft Windows [Version 10.0.19045.4291]
    II 11.2.0 (a64.win/100) 15807
    Python 3.10.7
    mock              5.1.0
    packaging         24.0
    pip               24.0
    pluggy            1.5.0
    pyodbc            5.1.0
    pyproject-api     1.6.1
    pypyodbc          1.3.6
    pytest            8.2.0
    setuptools        63.2.0
    SQLAlchemy        2.0.29.dev0
    sqlalchemy-ingres 0.0.7.dev4ingres
    tox               4.15.0
    typing_extensions 4.11.0
    virtualenv        20.26.2

Internal ticket [II-14372](https://actian.atlassian.net/browse/II-14372)
