### PR TITLE
Load iidbcapabilities and use to build column definition involving unique constraints

### DIFF
--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -81,8 +81,6 @@ ischema_names = {'ANSIDATE': types.Date,
            'TIMESTAMP WITH LOCAL TIME ZONE': types.TIMESTAMP,
            'VARCHAR': types.VARCHAR}
 
-iidbcapabilities = {}
-
 class _IngresBoolean(types.Boolean):
     def get_dbapi_type(self, dbapi):
         return dbapi.TINYINT
@@ -272,7 +270,7 @@ class IngresDDLCompiler(compiler.DDLCompiler):
                                 or constraint_column.primary_key is True
                                 or isinstance(constraint, sqlalchemy.sql.schema.UniqueConstraint)
                             ):
-                                if iidbcapabilities['DBMS_TYPE'] == 'INGRES':
+                                if self.dialect.iidbcapabilities['DBMS_TYPE'] == 'INGRES':
                                     colspec += " NOT NULL"
                                     break
         return colspec
@@ -390,7 +388,6 @@ class IngresDialect(default.DefaultDialect):
     max_identifier_length = 32  # FIXME review
     colspecs              = colspecs
     ischema_names         = ischema_names
-    iidbcapabilities      = iidbcapabilities
     statement_compiler    = IngresSQLCompiler
     type_compiler         = IngresTypeCompiler
     statement_compiler    = IngresSQLCompiler
@@ -408,6 +405,7 @@ class IngresDialect(default.DefaultDialect):
     requires_name_normalization = True
     sequences_optional    = False
     _isolation_lookup = isolation_lookup
+    iidbcapabilities      = None
     # TODO get_isolation_level()
     # TODO _check_max_identifier_length()
 
@@ -429,10 +427,10 @@ class IngresDialect(default.DefaultDialect):
         rs = None
         try:
             rs = connection.exec_driver_sql(sqltext)
-
+            self.iidbcapabilities = {}
             for row in rs.fetchall():
                 coldata = {}
-                iidbcapabilities[row[0].rstrip()] = row[1].rstrip()
+                self.iidbcapabilities[row[0].rstrip()] = row[1].rstrip()
 
             rs.close()
         finally:


### PR DESCRIPTION
### Overview
Method added for loading a dictionary of database values retrieved from the `iidbcapabilities` catalog upon initialization of the `IngresDialect` class. The dictionary can subsequently be used by `IngresDialect` class methods to query backend database settings.

Knowledge of the type of backend DBMS is then used in method `get_column_specification` to correctly handle whether a `NOT NULL` clause should be appended for columns in `CREATE TABLE` statements involving `UNIQUE` constraints when the backend is of type `INGRES`.

See documentation [link](https://docs.actian.com/actianx/12.0/index.html#page/SQLRef/Constraints.htm#ww124554) for information about the difference between Ingres and X100 tables for columns that are unique constraints.

The values in dictionary `iidbcapabilities` can be queried directly using known keys, although possibly creating internal _**getter**_ methods might be worth considering.

### Justification for changes
Allowing the dialect to know the backend database configuration is important in some cases when processing SQL statements.

Examples:
 - SQL statements may have different syntax rules depending on if the backend is `Ingres` or `X100`.
 - Alphabetic case settings can impact processing of object names (e.g. tables, columns) in SQL statements.

### SQLAlchemy standalone program used for testing changes

    import sqlalchemy as sa

    engine = sa.create_engine('ingres:///testdb', echo=True)
    metadata_obj = sa.MetaData()

    profile = sa.Table(
        'silly',
        metadata_obj,
        sa.Column('silly_id', sa.Integer, primary_key=True),
        sa.Column('address_id', sa.Integer),
    #    sa.Column('address_id', sa.Integer, nullable=False),
        sa.Column('name', sa.String),
        sa.Column('contact', sa.Integer),
        sa.UniqueConstraint('address_id', 'silly_id', name='zz_dingalings_multiple', comment='di unique comment'),
    )

    metadata_obj.create_all(engine)
 
### Testing with the SQLAlchemy Dialect Compliance Suite
**Test execution command:** `pytest --db %dsn% --maxfail=1000 .\test\dialect\test_suite.py`

#### Results
Using the SQLAlchemy Dialect Compliance Suite (`lib/sqlalchemy/testing/suite`)

Test Configuration | Passed | Failed | Errors | Skipped | Total
--|--|--|--|--|--
Ingres 11.2 without changes | 522 | 120 | 33 | 859 | 1534
Ingres 11.2 with changes | 529 | 113 | 33 | 859 | 1534
Vector 6.3 with or without changes | 323 | 68 | 785 _(a)_ | 358 | 1534

_(a) Of the 785 errors that occur when running the suite against Vector, 771 involve invalid SQL operations with X100 tables. These issues will be dealt with in part via internal issue [II-13753](https://actian.atlassian.net/browse/II-13753)._

### Environments

#### Windows 10 Client
    Python 3.10.7
    mock              5.1.0
    packaging         24.1
    pip               24.1.1
    platformdirs      4.2.2
    pluggy            1.5.0
    psycopg2          2.9.9
    pyodbc            5.1.0
    pyproject-api     1.7.1
    pypyodbc          1.3.6
    pytest            8.2.2
    setuptools        63.2.0
    SQLAlchemy        2.0.30.dev0
    sqlalchemy-ingres 0.0.7.dev6
    tox               4.15.1
    typing_extensions 4.12.2
    virtualenv        20.26.3

#### Backends

Ingres on Windows  

    Microsoft Windows [Version 10.0.19045.4412
    Ingres II 11.2.0 (a64.win/100) 15807

Vector on Ubuntu  

    Ubuntu 20.04.6 LTS
    VW 6.3.0 (a64.lnx/146) 14608
    