### PR TITLE
Publish version 0.0.7 then bump to version 0.0.8.dev0

### DIFF
--- a/lib/sqlalchemy_ingres/_version.py
+++ b/lib/sqlalchemy_ingres/_version.py
@@ -1,2 +1,2 @@
-version_tuple = __version_info__ = (0, 0, 7, "dev6")
+version_tuple = __version_info__ = (0, 0, 7)
 version = version_string = __version__ = '.'.join(map(str, __version_info__))

--- a/lib/sqlalchemy_ingres/_version.py
+++ b/lib/sqlalchemy_ingres/_version.py
@@ -1,2 +1,2 @@
-version_tuple = __version_info__ = (0, 0, 7)
+version_tuple = __version_info__ = (0, 0, 8, "dev0")
 version = version_string = __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
Version `0.0.7` published to https://pypi.org/project/sqlalchemy-ingres/.

Bumped version to `0.0.8.dev0` to prep for future changes.