### PR TITLE
Allow compatibility with SQLAlchemy 1.4.x

### DIFF
--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -235,7 +235,7 @@ class IngresDDLCompiler(compiler.DDLCompiler):
                     column.type, type_expression=column
                 )
             )
-        else:
+        else:   # SQLAlchemy v1.x path
             colspec = (
                 self.preparer.format_column(column)
                 + " "


### PR DESCRIPTION
### Overview
Resolution of broken compatibility between the SQLAlchemy-Ingres connector and version 1.4.x of SQLAlchemy.

Ingres connector versions 0.0.7 and 0.0.8 will not work with SQLAlchemy version 1.4.x and result in the following error:

      File "C:\test\.venv\lib\site-packages\sqlalchemy_ingres\base.py", line 36, in <module>
        from sqlalchemy.sql._typing import is_sql_compiler
    ModuleNotFoundError: No module named 'sqlalchemy.sql._typing'

The fix restores compatibility with SQLAlchemy version 1.4.x and maintains compatibility with SQLAlchemy version 2.0.x.

#### Internal tracking
[II-16194](https://actian.atlassian.net/browse/II-16194) ModuleNotFoundError: No module named 'sqlalchemy.sql._typing'
[II-16298](https://actian.atlassian.net/browse/II-16298) SQLAlchemy Ingres dialect compatibility with SQLAlchemy 2.0.x and 1.4.x

### Testing with the SQLAlchemy Dialect Compliance Suite
Dialect compliance suite [reference](https://github.com/sqlalchemy/sqlalchemy/blob/main/README.dialects.rst)

SQLAlchemy 1.4.54 | Pass | Fail | Error | Skipped | Total | Pass Rate _(a)_
--|--|--|--|--|--|--
Before Fix | - | - | - | - | Fails to run | 0%
After Fix | 246 | 55 | 30 | 285 | 616 | 74%

SQLAlchemy v2.0.36 | Pass | Fail | Error | Skipped | Total | Pass Rate _(a)_
--|--|--|--|--|--|--
Before Fix | 547 | 101 | 33 | 882 | 1563 | 80%
After Fix | 546 | 102 | 33 | 882 | 1563 | 80%

_(a) Excludes skipped tests_

It is important to note that there is odd inconsistency when running the SQLAlchemy dialect compliance suite. Often I have seen different results when running the suite multiple times with the exact same configuration. For example, running the suite 5 times in a row might produce 3 unique sets of results with slightly different pass/fail rates. My guess for a cause is that there must be timing issue causing a conflict in multiple tests accessing the same objects.

### Conditional Imports
The code changes use conditional imports in a couple of places. This directly violates [PEP 8](https://peps.python.org/pep-0008/) which states that `"Imports are always put at the top of the file"` although there is no mention of how to handle conditional imports.

I found this [article](https://allanderek.github.io/posts/import-placement/) which gives good advice on the issue and concludes by recommending that imports remain at the top of the module.

I'd like feedback from the reviewers on using conditional imports scattered throughout the code and expect that this will need to be changed by moving the imports to the top. I actually did try having the conditional imports at the top but ran into scope problems and didn't spend time figuring out how to fix, so left the code as is.

### SQLAlchemy-Ingres Version

Once the code changes are approved, the version of the Ingres connector will need to be changed (at a minimum removing `dev0`) before pushing to [PyPi](https://pypi.org/project/sqlalchemy-ingres/).