### PR TITLE
Format source files with pylama & black

### DIFF
--- a/lib/sqlalchemy_ingres/__init__.py
+++ b/lib/sqlalchemy_ingres/__init__.py
@@ -4,7 +4,11 @@
 # This module is part of SQLAlchemy and is released under
 # the Apache-2.0 License: https://opensource.org/license/apache-2-0/
 
-from sqlalchemy_ingres import base, ingresdbi, pyodbc  # , zxjdbc  # does not appear to be in SQLAlchemy 1.4.0b1
+from sqlalchemy_ingres import (
+    base,
+    ingresdbi,
+    pyodbc,
+)  # , zxjdbc  # does not appear to be in SQLAlchemy 1.4.0b1
 
 from ._version import __version__, __version_info__
 

--- a/lib/sqlalchemy_ingres/_version.py
+++ b/lib/sqlalchemy_ingres/_version.py
@@ -1,2 +1,2 @@
 version_tuple = __version_info__ = (0, 0, 9, "dev0")
-version = version_string = __version__ = '.'.join(map(str, __version_info__))
+version = version_string = __version__ = ".".join(map(str, __version_info__))

--- a/lib/sqlalchemy_ingres/_version.py
+++ b/lib/sqlalchemy_ingres/_version.py
@@ -1,2 +1,2 @@
-version_tuple = __version_info__ = (0, 0, 8)
+version_tuple = __version_info__ = (0, 0, 9, "dev0")
 version = version_string = __version__ = '.'.join(map(str, __version_info__))

--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -1,5 +1,5 @@
 # ingres/base.py
-# 
+#
 """Support for the Ingres Database
 
 Versions
@@ -21,22 +21,32 @@ ingres://server/database?uid=user;pwd=passwd;selectloops=y
 where server is the remote server name, or (LOCAL) if local,
       database is the name of the database to connect to,
       user is the username to connect as, if necessary and
-      passwd is the given user's password, if necessary. 
+      passwd is the given user's password, if necessary.
 
 """
 
 import sqlalchemy
-from typing import TYPE_CHECKING
 from sqlalchemy import types, schema
 from sqlalchemy.engine import cursor as _cursor
 from sqlalchemy.engine import default, reflection
 from sqlalchemy.schema import DDLElement
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql.expression import func
-from sqlalchemy.sql._typing import is_sql_compiler
+from sqlalchemy.sql.dml import DMLState
+from sqlalchemy.sql.selectable import TableClause
+from typing import TYPE_CHECKING
 
-#sqlalchemy_version_tuple = tuple(map(int, sqlalchemy.__version__.split('.')))  # TODO review - simplistic approach does not handle '1.4.0b1', consider using https://pypi.org/project/version-parser/
-sqlalchemy_version_tuple = tuple(map(int, sqlalchemy.__version__.split('.', 2)[0:2]))  # Only care about major and minor
+try:
+    from sqlalchemy.sql._typing import is_sql_compiler
+except ImportError:
+    is_sql_compiler = None
+
+
+# TODO review - simplistic approach does not handle '1.4.0b1', consider using https://pypi.org/project/version-parser/
+# sqlalchemy_version_tuple = tuple(map(int, sqlalchemy.__version__.split('.')))
+sqlalchemy_version_tuple = tuple(
+    map(int, sqlalchemy.__version__.split(".", 2)[0:2])
+)  # Only care about major and minor
 
 # https://docs.actian.com/actianx/11.1/index.html#page/SQLRef/TRANSACTION_ISOLATION_LEVEL.htm
 isolation_lookup = set(
@@ -48,48 +58,52 @@ isolation_lookup = set(
     ]
 )
 
-ischema_names = {'ANSIDATE': types.Date,
-           'BIGINT': types.BigInteger,
-           'BOOLEAN': types.BOOLEAN,
-           'BYTE': types.BINARY,
-           'BYTE VARYING': types.BINARY,
-           'C': types.TEXT,
-           'CHAR': types.CHAR,
-           'DATE': types.DateTime,
-           'DECIMAL': types.DECIMAL,
-           'FLOAT': types.Float,
-           'INGRESDATE': types.DateTime,
-           'INTEGER': types.Integer,
-           'INTERVAL YEAR TO MONTH': types.Interval,
-           'INTERVAL DAY TO SECOND': types.Interval,
-           'LONG BYTE': types.LargeBinary,
-           'LONG NVARCHAR': types.UnicodeText,
-           'LONG VARCHAR': types.CLOB,
-           'MONEY': types.DECIMAL,
-           'NCHAR': types.NCHAR,
-           'NVARCHAR': types.NVARCHAR,
-           #'OBJECT_KEY': types.,
-           #'TABLE_KEY':,
-           'SMALLINT': types.SmallInteger,
-           'TEXT': types.TEXT,
-           'TINYINT': types.SmallInteger,  # FIXME this is the wrong size but closest - TODO look at get_dbapi_type() / setinputsizes()
-           'TIME WITH TIME ZONE': types.TIME,
-           'TIME WITHOUT TIME ZONE': types.TIME,
-           'TIME WITH LOCAL TIME ZONE': types.TIME,
-           'TIMESTAMP WITH TIME ZONE': types.TIMESTAMP,
-           'TIMESTAMP WITHOUT TIME ZONE': types.TIMESTAMP,
-           'TIMESTAMP WITH LOCAL TIME ZONE': types.TIMESTAMP,
-           'VARCHAR': types.VARCHAR}
+ischema_names = {
+    "ANSIDATE": types.Date,
+    "BIGINT": types.BigInteger,
+    "BOOLEAN": types.BOOLEAN,
+    "BYTE": types.BINARY,
+    "BYTE VARYING": types.BINARY,
+    "C": types.TEXT,
+    "CHAR": types.CHAR,
+    "DATE": types.DateTime,
+    "DECIMAL": types.DECIMAL,
+    "FLOAT": types.Float,
+    "INGRESDATE": types.DateTime,
+    "INTEGER": types.Integer,
+    "INTERVAL YEAR TO MONTH": types.Interval,
+    "INTERVAL DAY TO SECOND": types.Interval,
+    "LONG BYTE": types.LargeBinary,
+    "LONG NVARCHAR": types.UnicodeText,
+    "LONG VARCHAR": types.CLOB,
+    "MONEY": types.DECIMAL,
+    "NCHAR": types.NCHAR,
+    "NVARCHAR": types.NVARCHAR,
+    # 'OBJECT_KEY': types.,
+    # 'TABLE_KEY':,
+    "SMALLINT": types.SmallInteger,
+    "TEXT": types.TEXT,
+    "TINYINT": types.SmallInteger,  # FIXME this is the wrong size but closest - TODO look at get_dbapi_type() / setinputsizes()
+    "TIME WITH TIME ZONE": types.TIME,
+    "TIME WITHOUT TIME ZONE": types.TIME,
+    "TIME WITH LOCAL TIME ZONE": types.TIME,
+    "TIMESTAMP WITH TIME ZONE": types.TIMESTAMP,
+    "TIMESTAMP WITHOUT TIME ZONE": types.TIMESTAMP,
+    "TIMESTAMP WITH LOCAL TIME ZONE": types.TIMESTAMP,
+    "VARCHAR": types.VARCHAR,
+}
+
 
 class _IngresBoolean(types.Boolean):
     def get_dbapi_type(self, dbapi):
         return dbapi.TINYINT
-    
+
     def result_processor(self, dialect, coltype):
         def process(value):
             if value is None:
                 return None
             return value and True or False
+
         return process
 
     def bind_processor(self, dialect):
@@ -102,105 +116,122 @@ class _IngresBoolean(types.Boolean):
                 return None
             else:
                 return value and True or False
+
         return process
-    
+
+
 class _IngresDateWithoutTime(types.Date):
     def get_dbapi_type(self, dbapi):
         return dbapi.DATE
-    
+
     def result_processor(self, dialect):
         def process(value):
             if value is None:
                 return None
-            
-            
+
+
 colspecs = {types.Boolean: _IngresBoolean}
+
 
 class IngresTypeCompiler(compiler.GenericTypeCompiler):
     def visit_TIME(self, type_):
         if type_.tzinfo is None:
-            return 'TIME WITHOUT TIME ZONE'
+            return "TIME WITHOUT TIME ZONE"
         else:
-            return 'TIME WITH TIME ZONE'
-        
+            return "TIME WITH TIME ZONE"
+
     def visit_BOOLEAN(self, type_):
         return self.visit_TINYINT(type_)
+
     def visit_TINYINT(self, type_):
-        return 'TINYINT'
+        return "TINYINT"
+
     def visit_DATETIME(self, type_):
-        return 'TIMESTAMP'
+        return "TIMESTAMP"
+
     def visit_DATE(self, type_):
-        return 'ANSIDATE'
+        return "ANSIDATE"
+
     def visit_CLOB(self, type_):
-        return 'LONG VARCHAR'
+        return "LONG VARCHAR"
+
     def visit_NCLOB(self, type_):
-        return 'LONG NVARCHAR'
+        return "LONG NVARCHAR"
+
     def visit_BLOB(self, type_):
         return "LONG BYTE"
+
     def visit_TEXT(self, type_):
         return self.visit_CLOB(type_)
+
     def visit_DECIMAL(self, type_):
         if type_.precision is None:
             return "DECIMAL"
         elif type_.scale is None:
-            return "DECIMAL(%(precision)s)" % {'precision': type_.precision}
+            return "DECIMAL(%(precision)s)" % {"precision": type_.precision}
         else:
-            return "DECIMAL(%(precision)s, %(scale)s)" % {'precision': type_.precision,
-                                                         'scale': type_.scale}
-    def visit_unicode(self,type_):
+            return "DECIMAL(%(precision)s, %(scale)s)" % {
+                "precision": type_.precision,
+                "scale": type_.scale,
+            }
+
+    def visit_unicode(self, type_):
         return self.visit_NVARCHAR(type_)
-    def visit_unicode_text(self,type_):
+
+    def visit_unicode_text(self, type_):
         return self.visit_NCLOB(type_)
-    
+
+
 class IngresSQLCompiler(compiler.SQLCompiler):
     def visit_sequence(self, seq, **kwargs):
         # NOTE this now silently ignores keyword argument 'literal_binds', etc.
-        return 'NEXT VALUE FOR %s' % self.preparer.format_sequence(seq)
-    
+        return "NEXT VALUE FOR %s" % self.preparer.format_sequence(seq)
+
     def limit_clause(self, select, **kwargs):
         # NOTE this now silently ignores keyword argument 'literal_binds', 'enclosing_alias', 'include_table', etc.
         text = ""
         if not self.is_subquery():
             if is_integer_greater_than_zero(select._offset):
-                text += '\nOFFSET %s' % select._offset
+                text += "\nOFFSET %s" % select._offset
             if is_integer_greater_than_zero(select._limit):
                 if is_integer_greater_than_zero(select._offset):
-               	    text += '\nFETCH FIRST %s ROWS ONLY' % select._limit
+                    text += "\nFETCH FIRST %s ROWS ONLY" % select._limit
                 else:
-               	    text += '\nLIMIT %s' % select._limit
+                    text += "\nLIMIT %s" % select._limit
         return text
-    
+
     def get_select_precolumns(self, select, **kwargs):
-        ## FIXME SA 1.4 code indicates this is going away and being replaced with -- `_expression.Select.prefix_with` should be used for special keywords at the start of a SELECT.
+        # FIXME SA 1.4 code indicates this is going away and being replaced with -- `_expression.Select.prefix_with` should be used for special keywords at the start of a SELECT.
         # NOTE this now silently ignores keyword argument 'literal_binds', 'enclosing_alias', 'eager_grouping', etc.
         s = ""
         if select._distinct and not self.is_subquery():
             s = " DISTINCT "
         return s
-        
+
     def visit_release_savepoint(self, savepoint_stmt):
         return ""
-    
+
+
 class _Modify(DDLElement):
     """Represents a MODIFY Statment"""
-    
+
     __visit_name__ = "modify"
-    
+
     def __init__(self, target, **kwargs):
         self.target = target
         self.kwargs = kwargs
 
-class IngresDDLCompiler(compiler.DDLCompiler):
 
+class IngresDDLCompiler(compiler.DDLCompiler):
     def visit_drop_constraint(self, drop):
         table = drop.element.table
         constr = drop.element
-        return 'ALTER TABLE %s DROP CONSTRAINT %s %s' % (
+        return "ALTER TABLE %s DROP CONSTRAINT %s %s" % (
             self.preparer.format_table(table),
             self.preparer.format_constraint(constr),
-            drop.cascade and 'CASCADE' or 'RESTRICT'
+            drop.cascade and "CASCADE" or "RESTRICT",
         )
-    
+
     def get_column_default_string(self, column):
         """
         import pdb ; pdb.set_trace()
@@ -212,23 +243,33 @@ class IngresDDLCompiler(compiler.DDLCompiler):
         elif isinstance(column.default, schema.Sequence):
         """
         if isinstance(column.default, schema.Sequence):
-            return 'NEXT VALUE FOR %s' % self.preparer.format_sequence(column.default)
+            return "NEXT VALUE FOR %s" % self.preparer.format_sequence(column.default)
         else:
             return None
 
     def get_column_specification(self, column, **kwargs):
-
         if str(column.type) == "VARCHAR":
-            if column.type.length is None:   # If no length is provided for VARCHAR column
-                column.type.length = 255     # Set length to 255
-        
-        colspec = (
-            self.preparer.format_column(column)
-            + " "
-            + self.dialect.type_compiler_instance.process(
-                column.type, type_expression=column
+            if (
+                column.type.length is None
+            ):  # If no length is provided for VARCHAR column
+                column.type.length = 255  # Set length to 255
+
+        if sqlalchemy_version_tuple >= (2, 0):
+            colspec = (
+                self.preparer.format_column(column)
+                + " "
+                + self.dialect.type_compiler_instance.process(
+                    column.type, type_expression=column
+                )
             )
-        )
+        else:  # SQLAlchemy v1.x path
+            colspec = (
+                self.preparer.format_column(column)
+                + " "
+                + self.dialect.type_compiler.process(
+                    column.type, type_expression=column
+                )
+            )
 
         default = self.get_column_default_string(column)
         if default is not None:
@@ -256,21 +297,31 @@ class IngresDDLCompiler(compiler.DDLCompiler):
             column.identity is not None
             or column.primary_key is True
             or not column.nullable
-            or (column.unique is True and self.dialect.iidbcapabilities['DBMS_TYPE'] == 'INGRES')
-            ):
-                colspec += " NOT NULL"
+            or (
+                column.unique is True
+                and self.dialect.iidbcapabilities["DBMS_TYPE"] == "INGRES"
+            )
+        ):
+            colspec += " NOT NULL"
         else:
             for constraint in column.table.constraints:
-                if constraint.contains_column(column):  # Maybe redundant since checked again in for loop
+                if constraint.contains_column(
+                    column
+                ):  # Maybe redundant since checked again in for loop
                     for constraint_column in constraint:
                         if constraint_column == column:
                             if (
                                 constraint_column.nullable is False
                                 or constraint_column.unique is True
                                 or constraint_column.primary_key is True
-                                or isinstance(constraint, sqlalchemy.sql.schema.UniqueConstraint)
+                                or isinstance(
+                                    constraint, sqlalchemy.sql.schema.UniqueConstraint
+                                )
                             ):
-                                if self.dialect.iidbcapabilities['DBMS_TYPE'] == 'INGRES':
+                                if (
+                                    self.dialect.iidbcapabilities["DBMS_TYPE"]
+                                    == "INGRES"
+                                ):
                                     colspec += " NOT NULL"
                                     break
         return colspec
@@ -278,64 +329,71 @@ class IngresDDLCompiler(compiler.DDLCompiler):
     def visit_create_index(self, create):
         text = compiler.DDLCompiler.visit_create_index(self, create)
         index = create.element
-        if 'ingres_structure' in index.kwargs:
-            text += ' WITH STRUCTURE=%s' % (index.kwargs['ingres_structure'])
-            if 'ingres_structure_keys' in index.kwargs:
-                if 'ingres_structure_key_unique' in index.kwargs \
-                and index.kwargs['ingres_structure_key_unique']:
-                    text += ' UNIQUE '
-                text += ' ON '
-                text += ", ".join(["%s" % col for col in index.kwargs['ingres_structure_keys']])
-                 
-        return text
-    
-    def post_create_table(self, table):        
-        if 'ingres_structure' in table.kwargs:
-            _Modify(table, **(table.kwargs)).execute_at("after-create", 
-                                                        table)
-        return ''
-    
-    def visit_modify(self, modify):
-        text = 'MODIFY %s TO ' % modify.target 
-        if 'ingres_structure' in modify.kwargs:
-            text += "%s" % modify.kwargs['ingres_structure']
-            
-            if 'ingres_structure_keys' in modify.kwargs:
-                if 'ingres_structure_key_unique' in modify.kwargs \
-                and modify.kwargs['ingres_structure_key_unique']:
-                    text += ' UNIQUE '
-                text += ' ON '
-                text += ", ".join(["%s" % col for col in modify.kwargs['ingres_structure_keys']])
+        if "ingres_structure" in index.kwargs:
+            text += " WITH STRUCTURE=%s" % (index.kwargs["ingres_structure"])
+            if "ingres_structure_keys" in index.kwargs:
+                if (
+                    "ingres_structure_key_unique" in index.kwargs
+                    and index.kwargs["ingres_structure_key_unique"]
+                ):
+                    text += " UNIQUE "
+                text += " ON "
+                text += ", ".join(
+                    ["%s" % col for col in index.kwargs["ingres_structure_keys"]]
+                )
+
         return text
 
-    
+    def post_create_table(self, table):
+        if "ingres_structure" in table.kwargs:
+            _Modify(table, **(table.kwargs)).execute_at("after-create", table)
+        return ""
+
+    def visit_modify(self, modify):
+        text = "MODIFY %s TO " % modify.target
+        if "ingres_structure" in modify.kwargs:
+            text += "%s" % modify.kwargs["ingres_structure"]
+
+            if "ingres_structure_keys" in modify.kwargs:
+                if (
+                    "ingres_structure_key_unique" in modify.kwargs
+                    and modify.kwargs["ingres_structure_key_unique"]
+                ):
+                    text += " UNIQUE "
+                text += " ON "
+                text += ", ".join(
+                    ["%s" % col for col in modify.kwargs["ingres_structure_keys"]]
+                )
+        return text
+
+
 class IngresExecutionContext(default.DefaultExecutionContext):
     _select_lastrowid = False
     _lastrowid = None
 
     def __init__(self, *args, **kwargs):
         default.DefaultExecutionContext.__init__(self, *args, **kwargs)
-        
+
     def fire_sequence(self, seq, type_):
-        return self._execute_scalar('SELECT NEXT VALUE FOR %s' \
-                                   % self.dialect.identifier_preparer.format_sequence(seq),
-                                   type_)
+        return self._execute_scalar(
+            "SELECT NEXT VALUE FOR %s"
+            % self.dialect.identifier_preparer.format_sequence(seq),
+            type_,
+        )
 
     def pre_exec(self):
         if self.isinsert:
             if TYPE_CHECKING:
-                assert is_sql_compiler(self.compiled)
+                if is_sql_compiler:
+                    assert is_sql_compiler(self.compiled)
                 assert isinstance(self.compiled.compile_state, DMLState)
-                assert isinstance(
-                    self.compiled.compile_state.dml_table, TableClause
-                )
+                assert isinstance(self.compiled.compile_state.dml_table, TableClause)
 
             tbl = self.compiled.compile_state.dml_table
             id_column = tbl._autoincrement_column
 
-            if id_column is not None: 
+            if id_column is not None:
                 insert_has_identity = True
-                compile_state = self.compiled.dml_compile_state
 
             else:
                 insert_has_identity = False
@@ -343,8 +401,12 @@ class IngresExecutionContext(default.DefaultExecutionContext):
             self._select_lastrowid = (
                 not self.compiled.inline
                 and insert_has_identity
-                and not self.compiled.effective_returning
                 and not self.executemany
+                and not (
+                    self.compiled.effective_returning
+                    if sqlalchemy_version_tuple >= (2, 0)
+                    else self.compiled.returning
+                )
             )
 
     def post_exec(self):
@@ -366,35 +428,39 @@ class IngresExecutionContext(default.DefaultExecutionContext):
                 self._lastrowid = int(row[0])
 
             self.cursor_fetch_strategy = _cursor._NO_CURSOR_DML
-        elif (
-            self.compiled is not None
-            and is_sql_compiler(self.compiled)
-            and self.compiled.effective_returning
-        ):
-            self.cursor_fetch_strategy = (
-                _cursor.FullyBufferedCursorFetchStrategy(
+        elif self.compiled is not None:
+            if (
+                sqlalchemy_version_tuple >= (2, 0)
+                and (is_sql_compiler(self.compiled) if is_sql_compiler else True)
+                and self.compiled.effective_returning
+                or (
+                    (self.isinsert or self.isupdate or self.isdelete)
+                    and self.compiled.returning
+                )
+            ):
+                self.cursor_fetch_strategy = _cursor.FullyBufferedCursorFetchStrategy(
                     self.cursor,
                     self.cursor.description,
                     self.cursor.fetchall(),
                 )
-            )
 
     def get_lastrowid(self):
         return self._lastrowid
-    
+
+
 class IngresDialect(default.DefaultDialect):
-    name                  = 'ingres'
-    default_paramstyle    = 'qmark'
+    name = "ingres"
+    default_paramstyle = "qmark"
     max_identifier_length = 32  # FIXME review
-    colspecs              = colspecs
-    ischema_names         = ischema_names
-    statement_compiler    = IngresSQLCompiler
-    type_compiler         = IngresTypeCompiler
-    statement_compiler    = IngresSQLCompiler
-    ddl_compiler          = IngresDDLCompiler
-    execution_ctx_cls     = IngresExecutionContext
+    colspecs = colspecs
+    ischema_names = ischema_names
+    statement_compiler = IngresSQLCompiler
+    type_compiler = IngresTypeCompiler
+    statement_compiler = IngresSQLCompiler
+    ddl_compiler = IngresDDLCompiler
+    execution_ctx_cls = IngresExecutionContext
     supports_identity_columns = True
-    supports_sequences    = True
+    supports_sequences = True
     supports_unicode_statements = True
     supports_unicode_binds = True
     supports_empty_insert = False
@@ -402,11 +468,11 @@ class IngresDialect(default.DefaultDialect):
     supports_statement_cache = False  # NOTE this is not actually picked up by SA warning code, _generate_cache_attrs() checks dict of subclass, not the entire class
     supports_schemas = False  # see README.testsuite.md for details
     supports_comments = True
-    postfetch_lastrowid   = True
+    postfetch_lastrowid = True
     requires_name_normalization = True
-    sequences_optional    = False
+    sequences_optional = False
     _isolation_lookup = isolation_lookup
-    iidbcapabilities      = None
+    iidbcapabilities = None
     # TODO get_isolation_level()
     # TODO _check_max_identifier_length()
 
@@ -430,7 +496,6 @@ class IngresDialect(default.DefaultDialect):
             rs = connection.exec_driver_sql(sqltext)
             self.iidbcapabilities = {}
             for row in rs.fetchall():
-                coldata = {}
                 self.iidbcapabilities[row[0].rstrip()] = row[1].rstrip()
 
             rs.close()
@@ -450,24 +515,27 @@ class IngresDialect(default.DefaultDialect):
             WHERE
                 object_name = ?
                 AND subobject_name = ?"""
-        params = (self.denormalize_name(table_name),self.denormalize_name(column_name),)
-        
+        params = (
+            self.denormalize_name(table_name),
+            self.denormalize_name(column_name),
+        )
+
         if schema:
             sqltext += """
                 AND table_owner = ?"""
             params = (*params, self.denormalize_name(schema))
-            
+
         rs = None
         try:
             rs = connection.exec_driver_sql(sqltext, params)
             row = rs.fetchone()
-            if (row is not None):
+            if row is not None:
                 return row[0]
         finally:
             if rs:
                 rs.close()
 
-    @reflection.cache        
+    @reflection.cache
     def get_columns(self, connection, table_name, schema=None, **kw):
         sqltext = """
             SELECT
@@ -484,63 +552,67 @@ class IngresDialect(default.DefaultDialect):
             WHERE
                 table_name = ?"""
         params = (self.denormalize_name(table_name),)
-        
+
         if schema:
             sqltext += """
                 AND table_owner = ?"""
             params = (*params, self.denormalize_name(schema))
-            
+
         sqltext += """
             ORDER BY
                 column_sequence"""
-            
+
         rs = None
         columns = []
         try:
             rs = connection.exec_driver_sql(sqltext, params)
-            
+
             for row in rs.fetchall():
                 coldata = {}
-                coldata['name'] = row[0].rstrip()
+                coldata["name"] = row[0].rstrip()
                 coltype = row[1].rstrip()
-                coldata['nullable'] = row[2].upper() == 'Y'
-                coldata['default'] = row[3]
-                if coltype == 'C' \
-                        or coltype == 'CHAR' \
-                        or coltype == 'VARCHAR' \
-                        or coltype == 'TEXT' \
-                        or coltype == 'NVARCHAR' \
-                        or coltype == 'NCHAR' \
-                        or coltype == 'BYTE' \
-                        or coltype == 'BYTE VARYING' \
-                        or coltype == 'FLOAT':
+                coldata["nullable"] = row[2].upper() == "Y"
+                coldata["default"] = row[3]
+                if (
+                    coltype == "C"
+                    or coltype == "CHAR"
+                    or coltype == "VARCHAR"
+                    or coltype == "TEXT"
+                    or coltype == "NVARCHAR"
+                    or coltype == "NCHAR"
+                    or coltype == "BYTE"
+                    or coltype == "BYTE VARYING"
+                    or coltype == "FLOAT"
+                ):
                     length = row[4]
-                    coldata['type'] = ischema_names[coltype](length)
-                elif coltype == 'INTEGER':
+                    coldata["type"] = ischema_names[coltype](length)
+                elif coltype == "INTEGER":
                     length = row[4]
                     if length == 1:
-                        coltype = 'TINYINT'
+                        coltype = "TINYINT"
                     elif length == 2:
-                        coltype = 'SMALLINT'
+                        coltype = "SMALLINT"
                     elif length == 4:
                         pass
                     elif length == 8:
-                        coltype = 'BIGINT'
+                        coltype = "BIGINT"
                     else:
                         pass  # TODO review, unlikely to happen should this be trapped?
-                    coldata['type'] = ischema_names[coltype]
-                elif coltype == 'DECIMAL':
+                    coldata["type"] = ischema_names[coltype]
+                elif coltype == "DECIMAL":
                     (precision, scale) = (row[4], row[5])
-                    coldata['type'] = ischema_names[coltype](precision, scale)
+                    coldata["type"] = ischema_names[coltype](precision, scale)
                 else:
-                    coldata['type'] = ischema_names[coltype]
+                    coldata["type"] = ischema_names[coltype]
                 # Check values for column_always_ident, column_bydefault_ident
-                coldata['autoincrement'] = (row[6] == 'Y' or row[7] == 'Y')
+                coldata["autoincrement"] = row[6] == "Y" or row[7] == "Y"
 
-                coldata['comment'] = self._get_column_comment(connection, table_name, coldata['name'], schema)
+                coldata["comment"] = self._get_column_comment(
+                    connection, table_name, coldata["name"], schema
+                )
 
                 columns.append(coldata)
-                
+
             rs.close()
             return columns
         finally:
@@ -561,12 +633,12 @@ class IngresDialect(default.DefaultDialect):
             AND c.constraint_type = 'U'
             AND k.table_name = ?"""
         params = (self.denormalize_name(table_name),)
-        
+
         if schema:
             sqltext += """
                 AND k.schema_name = ?"""
             params = (*params, self.denormalize_name(schema))
-        
+
         rs = None
 
         try:
@@ -579,15 +651,15 @@ class IngresDialect(default.DefaultDialect):
 
                 constraint_exists_in_list = False
                 for constraint_dict in constraints:
-                    if constraint_name == constraint_dict['name']:
-                        constraint_dict['column_names'].insert(0, column_name)
+                    if constraint_name == constraint_dict["name"]:
+                        constraint_dict["column_names"].insert(0, column_name)
                         constraint_exists_in_list = True
 
                 if not constraint_exists_in_list:
                     constraint_dict = {
-                            "name" : constraint_name if constraint_name[0] != '$' else None,
-                            "column_names" : [column_name]
-                        }
+                        "name": constraint_name if constraint_name[0] != "$" else None,
+                        "column_names": [column_name],
+                    }
                     constraints.append(constraint_dict)
 
             return constraints
@@ -595,7 +667,7 @@ class IngresDialect(default.DefaultDialect):
         finally:
             if rs:
                 rs.close()
-                
+
     @reflection.cache
     def get_primary_keys(self, connection, table_name, schema=None, **kw):
         sqltext = """
@@ -609,14 +681,14 @@ class IngresDialect(default.DefaultDialect):
             AND c.constraint_type = 'P'
             AND k.table_name = ?"""
         params = (self.denormalize_name(table_name),)
-        
+
         if schema:
             sqltext += """
                 AND k.schema_name = ?"""
             params = (*params, self.denormalize_name(schema))
-        
+
         rs = None
-        
+
         try:
             rs = connection.exec_driver_sql(sqltext, params)
 
@@ -653,52 +725,52 @@ class IngresDialect(default.DefaultDialect):
             AND p.key_position = f.key_position
             AND f.table_name = ?"""
         params = (self.denormalize_name(table_name),)
-        
+
         if schema:
             sqltext += """
                 AND f.schema_name = ?"""
             params = (*params, self.denormalize_name(schema))
-            
+
         sqltext += """
-            ORDER BY 
+            ORDER BY
                 f.key_position"""
-        
+
         rs = None
         foreign_keys = {}
         try:
             rs = connection.exec_driver_sql(sqltext, params)
-            
+
             for row in rs.fetchall():
                 name = row[0].rstrip()
                 if name in foreign_keys:
                     constraint = foreign_keys[name]
                 else:
                     constraint = {}
-                    constraint['name'] = name
-                    constraint['constrained_columns'] = []
-                    constraint['referred_table'] = row[3].rstrip()
-                    constraint['referred_columns'] = []
-                    
+                    constraint["name"] = name
+                    constraint["constrained_columns"] = []
+                    constraint["referred_table"] = row[3].rstrip()
+                    constraint["referred_columns"] = []
+
                     ref_schema = row[2].rstrip()
                     def_schema = connection.dialect.default_schema_name
-                    
+
                     if def_schema != ref_schema:
-                        constraint['referred_schema'] = ref_schema
+                        constraint["referred_schema"] = ref_schema
                     else:
-                        constraint['referred_schema'] = None
-                    #constraint['referred_schema'] = row[2].rstrip()
-                
-                constraint['constrained_columns'].append(row[1].rstrip())
-                constraint['referred_columns'].append(row[4].rstrip())
-                
+                        constraint["referred_schema"] = None
+                    # constraint['referred_schema'] = row[2].rstrip()
+
+                constraint["constrained_columns"].append(row[1].rstrip())
+                constraint["referred_columns"].append(row[4].rstrip())
+
                 foreign_keys[name] = constraint
-                
+
             rs.close()
             return list(foreign_keys.values())
         finally:
             if rs:
                 rs.close()
-    
+
     @reflection.cache
     def get_table_names(self, connection, schema=None, **kw):
         sqltext = """
@@ -709,54 +781,54 @@ class IngresDialect(default.DefaultDialect):
             WHERE
                 table_type = 'T'"""
         params = None
-                
+
         if schema:
             sqltext += """
                 AND table_owner = ?"""
             params = (self.denormalize_name(schema),)
-            
+
             if schema != "$ingres":
                 sqltext += " AND table_name NOT LIKE 'ii%'"
         else:
             sqltext += """
                 AND table_owner != '$ingres'
                 AND table_name NOT LIKE 'ii%'"""
-            
+
         rs = None
-        
+
         try:
             if params:
                 rs = connection.exec_driver_sql(sqltext, params)
             else:
                 # sqlalchemy assumes anything after query text is a list/tuple of values
                 rs = connection.exec_driver_sql(sqltext)
-        
+
             return [row[0].rstrip() for row in rs.fetchall()]
         finally:
             if rs:
                 rs.close()
 
-    @reflection.cache                
+    @reflection.cache
     def get_schema_names(self, connection, **kw):
         sqltext = """
             SELECT
                 schema_name
-            FROM 
+            FROM
                 iischema"""
-                
+
         rs = None
-        
+
         try:
             rs = connection.exec_driver_sql(sqltext)
-            
+
             return [row[0].rstrip() for row in rs.fetchall()]
         finally:
             if rs:
                 rs.close()
-                
+
     def table_names(self, connection, schema=None, **kw):
         return self.get_table_names(connection, schema, **kw)
-    
+
     @reflection.cache
     def get_view_names(self, connection, schema=None, **kw):
         sqltext = """
@@ -765,7 +837,7 @@ class IngresDialect(default.DefaultDialect):
             FROM
                 iiviews"""
         params = None
-        
+
         if schema:
             sqltext += """
                 WHERE
@@ -773,17 +845,17 @@ class IngresDialect(default.DefaultDialect):
             params = (self.denormalize_name(schema),)
         else:
             sqltext += """
-                WHERE 
+                WHERE
                     table_owner != '$ingres'"""
-            
+
         rs = None
-        
+
         try:
             if params:
                 rs = connection.exec_driver_sql(sqltext, params)
             else:
                 rs = connection.exec_driver_sql(sqltext)
-            
+
             return [row[0].rstrip() for row in rs.fetchall()]
         finally:
             if rs:
@@ -799,7 +871,7 @@ class IngresDialect(default.DefaultDialect):
             WHERE
                 table_name = ?"""
         params = (self.denormalize_name(view_name),)
-        
+
         if schema:
             sqltext += """
                 AND table_owner = ?"""
@@ -807,21 +879,21 @@ class IngresDialect(default.DefaultDialect):
         else:
             sqltext += """
                 AND table_owner != '$ingres'"""
-            
+
         sqltext += """
             ORDER BY
                 text_sequence"""
-                
+
         rs = None
-        
+
         try:
             rs = connection.exec_driver_sql(sqltext, params)
-            
+
             return "".join([row[0] for row in rs.fetchall()])
         finally:
             if rs:
                 rs.close()
-    
+
     @reflection.cache
     def get_indexes(self, connection, table_name, schema=None, **kw):
         sqltext = """
@@ -838,70 +910,71 @@ class IngresDialect(default.DefaultDialect):
             AND i.base_name = ?"""
         params = (self.denormalize_name(table_name),)
 
-        if (connection.get_execution_options().get('inspect_indexes') is None or
-            connection.get_execution_options().get('inspect_indexes').upper() != "ALL"):
-                sqltext += """
-                    AND i.system_use = 'U'"""
-        
+        if (
+            connection.get_execution_options().get("inspect_indexes") is None
+            or connection.get_execution_options().get("inspect_indexes").upper()
+            != "ALL"
+        ):
+            sqltext += """
+                AND i.system_use = 'U'"""
+
         if schema:
             sqltext += """
                 AND i.index_owner = ?"""
             params = (*params, self.denormalize_name(schema))
-            
+
         sqltext += """
             ORDER BY
                 c.key_sequence"""
-                
+
         rs = None
         indexes = {}
 
         try:
             rs = connection.exec_driver_sql(sqltext, params)
-            
+
             for row in rs.fetchall():
                 name = row[0].rstrip()
                 if name in indexes:
                     index = indexes[name]
                 else:
                     index = {}
-                    index['name'] = name
-                    index['column_names'] = []
-                    index['unique'] = row[2] == 'U'
-                    
-                index['column_names'].append(row[1].rstrip())
-                
+                    index["name"] = name
+                    index["column_names"] = []
+                    index["unique"] = row[2] == "U"
+
+                index["column_names"].append(row[1].rstrip())
+
                 indexes[name] = index
-                
+
             return list(indexes.values())
         finally:
             if rs:
                 rs.close()
-                    
-    
+
     def normalize_name(self, name):
         if name is None:
             return None
         else:
             return name
-        
-    
+
     def denormalize_name(self, name):
         if name is None:
             return None
         else:
             return name
-        
+
     def has_table(self, connection, table_name, schema=None):
         sqltext = """
-            SELECT 
+            SELECT
                 table_name
-            FROM 
+            FROM
                 iitables
             WHERE
                 table_name = ?
             AND table_type = 'T'"""
         params = (self.denormalize_name(table_name),)
-        
+
         if schema:
             sqltext += """
                 AND table_owner = ?"""
@@ -914,7 +987,7 @@ class IngresDialect(default.DefaultDialect):
         finally:
             if rs:
                 rs.close()
-            
+
     def has_sequence(self, connection, sequence_name, schema=None):
         sqltext = """
             SELECT
@@ -924,36 +997,36 @@ class IngresDialect(default.DefaultDialect):
             WHERE
                 seq_name = ?"""
         params = (self.denormalize_name(sequence_name),)
-        
+
         if schema:
             sqltext += """
                 AND seq_owner = ?"""
             params = (*params, self.denormalize_name(schema))
-            
+
         rs = None
-        
+
         try:
             rs = connection.exec_driver_sql(sqltext, params)
             return len(rs.fetchall()) > 0
         finally:
             if rs:
                 rs.close()
-    
+
     def get_default_schema_name(self, connection):
         rs = None
         try:
-            if (sqlalchemy_version_tuple >= (2,0)):
-                rs = connection.execute(func.dbmsinfo('username'))
+            if sqlalchemy_version_tuple >= (2, 0):
+                rs = connection.execute(func.dbmsinfo("username"))
             else:
                 sqltext = """SELECT dbmsinfo('username')"""
-                rs = connection.execute(sqltext)
+                rs = connection.exec_driver_sql(sqltext)
             return rs.fetchone()[0]
         finally:
             if rs:
                 rs.close()
+
     _get_default_schema_name = get_default_schema_name  # 1.4 API
 
 
 def is_integer_greater_than_zero(check_value):
     return check_value is not None and check_value > 0
-

--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -32,7 +32,6 @@ from sqlalchemy.engine import default, reflection
 from sqlalchemy.schema import DDLElement
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql.expression import func
-
 from sqlalchemy.sql.dml import DMLState
 from sqlalchemy.sql.selectable import TableClause
 from typing import TYPE_CHECKING

--- a/lib/sqlalchemy_ingres/ingresdbi.py
+++ b/lib/sqlalchemy_ingres/ingresdbi.py
@@ -11,27 +11,32 @@ from sqlalchemy.engine.default import DefaultExecutionContext
 from sqlalchemy_ingres.base import IngresDialect
 from sqlalchemy_ingres.base import sqlalchemy_version_tuple
 
+
 class Ingres_ingresdbi(IngresDialect):
-    driver = 'ingresdbi'
+    driver = "ingresdbi"
     supports_statement_cache = False  # NOTE `IngresDialect.supports_statement_cache` is not actually picked up by SA warning code, _generate_cache_attrs() checks dict of subclass, not the entire class
 
     def __init__(self, **kwargs):
         IngresDialect.__init__(self, **kwargs)
 
-    if (sqlalchemy_version_tuple >= (2,0)):
+    if sqlalchemy_version_tuple >= (2, 0):
+
         @classmethod
         def import_dbapi(cls):
-            return __import__('ingresdbi')
+            return __import__("ingresdbi")
+
     else:
+
         @classmethod
         def dbapi(cls):
-            return __import__('ingresdbi')
+            return __import__("ingresdbi")
 
     def create_connect_args(self, url):
-        opts = url.translate_connect_args(username='uid', password='pwd', host='vnode')
+        opts = url.translate_connect_args(username="uid", password="pwd", host="vnode")
         opts.update(url.query)
 
         return ([], opts)
+
 
 class IngresExecutionContext(DefaultExecutionContext):
     def __init__(self, **kwargs):
@@ -39,5 +44,6 @@ class IngresExecutionContext(DefaultExecutionContext):
 
     def create_cursor(self):
         return self._connection.connection.cursor()
+
 
 dialect = Ingres_ingresdbi

--- a/lib/sqlalchemy_ingres/provision.py
+++ b/lib/sqlalchemy_ingres/provision.py
@@ -1,6 +1,6 @@
 from sqlalchemy.testing.provision import temp_table_keyword_args
 
+
 @temp_table_keyword_args.for_db("ingres")
 def _ingres_temp_table_keyword_args(cfg, eng):
     return {}
-

--- a/lib/sqlalchemy_ingres/pyodbc.py
+++ b/lib/sqlalchemy_ingres/pyodbc.py
@@ -20,54 +20,61 @@ except NameError:
 
 
 class Ingres_pyodbc(IngresDialect):
-    driver = 'pyodbc'
+    driver = "pyodbc"
     supports_statement_cache = False  # quiesce https://sqlalche.me/e/14/cprf  NOTE `IngresDialect.supports_statement_cache` is not actually picked up by SA warning code, _generate_cache_attrs() checks dict of subclass, not the entire class
 
     def __init__(self, **kwargs):
         IngresDialect.__init__(self, **kwargs)
 
-    if (sqlalchemy_version_tuple >= (2,0)):
+    if sqlalchemy_version_tuple >= (2, 0):
+
         @classmethod
         def import_dbapi(cls):
             try:
                 driver = __import__(Ingres_pyodbc.driver)
             except ModuleNotFoundError:
                 # fallback to pure Python version
-                Ingres_pyodbc.driver = 'pypyodbc'
+                Ingres_pyodbc.driver = "pypyodbc"
                 driver = __import__(Ingres_pyodbc.driver)
             return driver
+
     else:
+
         @classmethod
         def dbapi(cls):
             try:
                 driver = __import__(Ingres_pyodbc.driver)
             except ModuleNotFoundError:
                 # fallback to pure Python version
-                Ingres_pyodbc.driver = 'pypyodbc'
+                Ingres_pyodbc.driver = "pypyodbc"
                 driver = __import__(Ingres_pyodbc.driver)
             return driver
 
     def create_connect_args(self, url):
-        opts = url.translate_connect_args(username='uid', password='pwd', host='vnode')
-        driver_name = os.environ.get('SQLALCHEMY_INGRES_ODBC_DRIVER_NAME') or 'Actian'  # TODO search driver list for Ingres and Actian, also attempt to find local version using II_INSTALLATION symbol table (if available)
+        opts = url.translate_connect_args(username="uid", password="pwd", host="vnode")
+        driver_name = (
+            os.environ.get("SQLALCHEMY_INGRES_ODBC_DRIVER_NAME") or "Actian"
+        )  # TODO search driver list for Ingres and Actian, also attempt to find local version using II_INSTALLATION symbol table (if available)
 
         conn_list = []
-        conn_list.append('Driver={' + driver_name + '}')  # FIXME using concat for now
-        conn_list.append('Database=' + url.database)
+        conn_list.append("Driver={" + driver_name + "}")  # FIXME using concat for now
+        if url.database:
+            # database may not be needed for dialect operations without a database connnection
+            conn_list.append("Database=" + url.database)
         if not url.host:
-            conn_list.append('Server=(local)')
+            conn_list.append("Server=(local)")
         else:
-            #conn_list.append('Server=' + url.host)  # for vnodes only - FIXME look at handling vnodes
-            conn_list.append('HostName=' + url.host)
-            conn_list.append('ListenAddress=' + str(url.port))
+            # conn_list.append('Server=' + url.host)  # for vnodes only - FIXME look at handling vnodes
+            conn_list.append("HostName=" + url.host)
+            conn_list.append("ListenAddress=" + str(url.port))
             # FIXME port - str(url.port)
-            
-        if url.username:
-            conn_list.append('UID=' + url.username)
-        if url.password:
-            conn_list.append('PWD=' + url.password)
 
-        connection_str = ';'.join(conn_list)
+        if url.username:
+            conn_list.append("UID=" + url.username)
+        if url.password:
+            conn_list.append("PWD=" + url.password)
+
+        connection_str = ";".join(conn_list)
 
         opts = {}
         opts.update(url.query)
@@ -82,5 +89,6 @@ class IngresExecutionContext(DefaultExecutionContext):
 
     def create_cursor(self):
         return self._connection.connection.cursor()
+
 
 dialect = Ingres_pyodbc

--- a/lib/sqlalchemy_ingres/requirements.py
+++ b/lib/sqlalchemy_ingres/requirements.py
@@ -5,6 +5,7 @@ from sqlalchemy.testing import exclusions
 supported = exclusions.open
 unsupported = exclusions.closed
 
+
 class Requirements(SuiteRequirements):
     @property
     def date_historic(self):
@@ -51,5 +52,3 @@ class Requirements(SuiteRequirements):
     @property
     def temp_table_reflection(self):
         return unsupported()
-
-

--- a/lib/sqlalchemy_ingres/zxjdbc.py
+++ b/lib/sqlalchemy_ingres/zxjdbc.py
@@ -12,12 +12,14 @@ http://esd.ingres.com
 from sqlalchemy.connectors.zxJDBC import ZxJDBCConnector
 from sqlalchemy_ingres.base import IngresDialect
 
+
 class Ingres_zxjdbc(ZxJDBCConnector, IngresDialect):
-    jdbc_db_name = 'ingres'
-    jdbc_driver_name = 'com.ingres.jdbc.IngresDriver'
+    jdbc_db_name = "ingres"
+    jdbc_driver_name = "com.ingres.jdbc.IngresDriver"
     supports_statement_cache = False  # NOTE `IngresDialect.supports_statement_cache` is not actually picked up by SA warning code, _generate_cache_attrs() checks dict of subclass, not the entire class
 
     def _get_server_version_info(self, connection):
         return connection.connection.dbversion
+
 
 dialect = Ingres_zxjdbc

--- a/setup.py
+++ b/setup.py
@@ -42,21 +42,21 @@ exec(open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'lib', 'sqlal
 print("Current version is: %s\n" % __version__)
 
 setup(
-    name = "sqlalchemy-ingres",  # note hypen, not underscore
-    version = __version__,
-    author = "Chris Clark",
-    author_email = "Chris.Clark@actian.com",
+    name="sqlalchemy-ingres",  # note hypen, not underscore
+    version=__version__,
+    author="Chris Clark",
+    author_email="Chris.Clark@actian.com",
     url="https://github.com/ActianCorp/sqlalchemy-ingres",
-    description = "SQLAlchemy dialect for Actian databases; Actian Data Platform (nee Avalanche), Actian X, Ingres, and Vector",
+    description="SQLAlchemy dialect for Actian databases; Actian Data Platform (nee Avalanche), Actian X, Ingres, and Vector",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    maintainer = "Michael Habiger",
-    maintainer_email = "michael.habiger@hcl-software.com",
+    maintainer="Michael Habiger",
+    maintainer_email="michael.habiger@hcl-software.com",
 
-    license = "Apache-2.0",
+    license="Apache-2.0",
 
     packages=find_packages('lib'),  # TODO review, remove and replace with static and py_modules
-    package_dir={'':'lib'},
+    package_dir={'': 'lib'},
 
     classifiers=[  # See http://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 4 - Beta',
@@ -69,19 +69,19 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Topic :: Database',
         'Programming Language :: SQL',
-        ],
+    ],
     platforms='any',  # or distutils.util.get_platform()
     install_requires=['sqlalchemy'],
     extras_require={
-        'pyodbc' : ['pyodbc', ],
-        'pypyodbc' : ['pypyodbc', ],
-        'all' : ['pypyodbc', 'pyodbc', ],
+        'pyodbc': ['pyodbc', ],
+        'pypyodbc': ['pypyodbc', ],
+        'all': ['pypyodbc', 'pyodbc', ],
     },
 
-    entry_points = {                                                
-        'sqlalchemy.dialects': [                                    
+    entry_points={
+        'sqlalchemy.dialects': [
             'ingres = sqlalchemy_ingres:base.dialect',  # note underscore, not hypen
             'ingres.pyodbc = sqlalchemy_ingres.pyodbc:Ingres_pyodbc'  # note underscore, not hypen
-        ]                                                           
-    }                                                               
+        ]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ from setuptools import setup, find_packages
 
 
 if len(sys.argv) <= 1:
-    print("""
+    print(
+        """
 Suggested setup.py parameters:
 
     * build
@@ -25,10 +26,11 @@ PyPi:
     #twine upload dist/*
     python setup.py  sdist ; twine upload dist/* --verbose
 
-""")
+"""
+    )
 
 
-readme_filename = 'README.md'
+readme_filename = "README.md"
 if os.path.exists(readme_filename):
     f = open(readme_filename)
     long_description = f.read()
@@ -37,7 +39,16 @@ else:
     long_description = None
 
 # pick up version number, __version__
-exec(open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'lib', 'sqlalchemy_ingres', '_version.py')).read())
+exec(
+    open(
+        os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            "lib",
+            "sqlalchemy_ingres",
+            "_version.py",
+        )
+    ).read()
+)
 
 print("Current version is: %s\n" % __version__)
 
@@ -49,39 +60,44 @@ setup(
     url="https://github.com/ActianCorp/sqlalchemy-ingres",
     description="SQLAlchemy dialect for Actian databases; Actian Data Platform (nee Avalanche), Actian X, Ingres, and Vector",
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     maintainer="Michael Habiger",
     maintainer_email="michael.habiger@hcl-software.com",
-
     license="Apache-2.0",
-
-    packages=find_packages('lib'),  # TODO review, remove and replace with static and py_modules
-    package_dir={'': 'lib'},
-
+    packages=find_packages(
+        "lib"
+    ),  # TODO review, remove and replace with static and py_modules
+    package_dir={"": "lib"},
     classifiers=[  # See http://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'Development Status :: 4 - Beta',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.12',
-        'Topic :: Database',
-        'Programming Language :: SQL',
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.12",
+        "Topic :: Database",
+        "Programming Language :: SQL",
     ],
-    platforms='any',  # or distutils.util.get_platform()
-    install_requires=['sqlalchemy'],
+    platforms="any",  # or distutils.util.get_platform()
+    install_requires=["sqlalchemy"],
     extras_require={
-        'pyodbc': ['pyodbc', ],
-        'pypyodbc': ['pypyodbc', ],
-        'all': ['pypyodbc', 'pyodbc', ],
+        "pyodbc": [
+            "pyodbc",
+        ],
+        "pypyodbc": [
+            "pypyodbc",
+        ],
+        "all": [
+            "pypyodbc",
+            "pyodbc",
+        ],
     },
-
     entry_points={
-        'sqlalchemy.dialects': [
-            'ingres = sqlalchemy_ingres:base.dialect',  # note underscore, not hypen
-            'ingres.pyodbc = sqlalchemy_ingres.pyodbc:Ingres_pyodbc'  # note underscore, not hypen
+        "sqlalchemy.dialects": [
+            "ingres = sqlalchemy_ingres:base.dialect",  # note underscore, not hypen
+            "ingres.pyodbc = sqlalchemy_ingres.pyodbc:Ingres_pyodbc",  # note underscore, not hypen
         ]
-    }
+    },
 )


### PR DESCRIPTION
### Overview

Python code formatting tools `black` and `pylama` were used to format the Ingres connector source files.

Internal tracking [II-16370](https://actian.atlassian.net/browse/II-16370)

### Installed packages

    black             24.10.0
    pylama            8.4.1

### Documentation references
https://black.readthedocs.io/en/stable/index.html
https://klen.github.io/pylama/

### Notes on formatting

All formatting recommendations from running `black` were implemented.

Most formatting recommendations from running `pylama` were implemented. For each of the Ingres connector source files, only the following recommendations were _not_ implemented. This was my decision to not make the remaining shown changes. Feedback is welcome!

#### __init__.py

    __init__.py:7:1 W0611 'sqlalchemy_ingres.ingresdbi' imported but unused [pyflakes]
    __init__.py:13:1 W0611 '._version.__version__' imported but unused [pyflakes]

#### _version.py

_(All formatting recommendations were implemented)_

#### base.py

    base.py:45:101 E501 line too long (118 > 100 characters) [pycodestyle]
    base.py:86:101 E501 line too long (128 > 100 characters) [pycodestyle]
    base.py:191:101 E501 line too long (115 > 100 characters) [pycodestyle]
    base.py:204:101 E501 line too long (178 > 100 characters) [pycodestyle]
    base.py:205:101 E501 line too long (116 > 100 characters) [pycodestyle]
    base.py:250:5 C901 'IngresDDLCompiler.get_column_specification' is too complex (15) [mccabe]
    base.py:468:101 E501 line too long (165 > 100 characters) [pycodestyle]
    base.py:539:5 C901 'IngresDialect.get_columns' is too complex (11) [mccabe]

#### ingresdbi.py

    ingresdbi.py:17:101 E501 line too long (201 > 100 characters) [pycodestyle]

#### provision.py

_(All formatting recommendations were implemented)_

#### pyodbc.py
    pyodbc.py:24:101 E501 line too long (240 > 100 characters) [pycodestyle]
    pyodbc.py:57:101 E501 line too long (144 > 100 characters) [pycodestyle]
    pyodbc.py:67:101 E501 line too long (103 > 100 characters) [pycodestyle]

#### requirements.py

_(All formatting recommendations were implemented)_

#### zxjdbc.py

    zxjdbc.py:19:101 E501 line too long (201 > 100 characters) [pycodestyle]

#### setup.py

    setup.py:53:36 E0602 undefined name '__version__' [pyflakes]
    setup.py:57:13 E0602 undefined name '__version__' [pyflakes]
    setup.py:61:101 E501 line too long (126 > 100 characters) [pycodestyle]

### Comparison of SQLAlchemy test suite performance before and after code formatting changes

Ran the SQLAlchemy test suite versions 1.4.54 and 2.0.36 and concluded that there is no impact to the overall results compared to running the test suites with the original source files prior to reformatting with tools `black` and `pylama`.

