### PR TITLE
add kwargs to `has_table`

### DIFF
--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -935,7 +935,7 @@ class IngresDialect(default.DefaultDialect):
         else:
             return name
 
-    def has_table(self, connection, table_name, schema=None):
+    def has_table(self, connection, table_name, schema=None, **kw):
         sqltext = """
             SELECT
                 table_name


### PR DESCRIPTION
Fixes the `TypeError: IngresDialect.has_table() got an unexpected keyword argument 'info_cache'` when using the dialect with Pandas `read_sql_table`