### PR TITLE
Add kwargs to has_sequence

### DIFF
--- a/lib/sqlalchemy_ingres/base.py
+++ b/lib/sqlalchemy_ingres/base.py
@@ -959,7 +959,7 @@ class IngresDialect(default.DefaultDialect):
             if rs:
                 rs.close()
 
-    def has_sequence(self, connection, sequence_name, schema=None):
+    def has_sequence(self, connection, sequence_name, schema=None, **kw):
         sqltext = """
             SELECT
                 seq_name


### PR DESCRIPTION
Add kwargs param to `IngresDialect::has_sequence` definition.

Allows the inherited method to match the current parent class.

Similar to PR #75 which added the kwargs param to `IngresDialect::has_table`.

SQLAlchemy documentation reference:
https://docs.sqlalchemy.org/en/20/core/internals.html#sqlalchemy.engine.default.DefaultDialect.has_sequence

