### PR TITLE
Readme update that explains how to include and/or skip testsuite tests

### DIFF
--- a/README.testsuite.md
+++ b/README.testsuite.md
@@ -123,6 +123,15 @@ The code changes are not required for any SQLAlchemy 2.x testing (unit or dialec
 
     C:\test\sqlalchemy> pytest --maxfail=10000 --db ingres_odbc .\test
 
+#### Execute a specific set/class of tests
+
+    C:\test\sqlalchemy> pytest --maxfail=50 --db dsn1 .\test\dialect\test_suite.py -k "CompoundSelectTest"
+
+#### Execute a set/class of tests and exclude specific tests within that set
+
+    C:\test\sqlalchemy> pytest --maxfail=50 --db dsn1 .\test\dialect\test_suite.py
+        -k "OrderByLabelTest and not test_composed_int and not test_plain_desc"  
+
 ### Helpful pytest documentation links
  - [https://docs.pytest.org/en/stable/](https://docs.pytest.org/en/stable/)
  - [https://naveens33.github.io/pytest-tutorial/docs/commandlineoptions.html](https://naveens33.github.io/pytest-tutorial/docs/commandlineoptions.html)
@@ -279,6 +288,13 @@ In addition, we probably don't want the Ingres dialect to forcibly exclude the O
 
 Therefore, the proper behavior should probably be what occurs already against Ingres, which is a syntax error informing the user
  that the ORDER BY clause is not allowed for a SELECT statement involved in a UNION clause.
+
+A workaround is to skip the failing tests using the pytest `-k` option which allows including and excluding specific tests.
+
+    pytest --db ingres_odbc --maxfail=50 .\test\dialect\test_suite.py
+        -k "CompoundSelectTest and not test_limit_offset_in_unions_from_alias
+            and not test_limit_offset_selectable_in_unions
+            and not test_order_by_selectable_in_unions"
 
 Internal issue [II-14232](https://actian.atlassian.net/browse/II-14232)
 


### PR DESCRIPTION
Internal issue [II-14232](https://actian.atlassian.net/issues/II-14232) documents failures that occur when attempting to run certain tests from the `CompoundSelectTest` class of the SQLAlchemy [dialect compliance suite](https://github.com/sqlalchemy/sqlalchemy/tree/main/lib/sqlalchemy/testing/suite) against tables in an Ingres database.

The failures occur because the tests involve SQL statements that are not supported by Ingres. The invalid SQL statements attempt to perform a UNION of SELECT statements that each have their own ORDER BY clause.

I discussed with a SQL contact who indicated that the most recent published SQL 9075 standard does not allow individual ORDER BY clauses for SELECT statements that are part of a UNION.

This README update provides some guidance on how to skip specific tests such as those that fail due to invalid SQL.

### pytest Examples

Example 1 | Include only tests from class CompoundSelectTest
--|--
Command | pytest --db ingres_odbc --maxfail=50 .\test\dialect\test_suite.py -k "CompoundSelectTest" --tb=no
Results | 5 failed, 7 passed, 1522 deselected

Example 2 | Same command used again but with added exclusions:
--|--
Command | pytest --db ingres_odbc --maxfail=50 .\test\dialect\test_suite.py -k "CompoundSelectTest<br> and not test_limit_offset_in_unions_from_alias and not test_limit_offset_selectable_in_unions<br> and not test_order_by_selectable_in_unions" --tb=no
Results | 7 passed, 1527 deselected